### PR TITLE
Fix compilation when stats are not enabled.

### DIFF
--- a/cryptominisat4/clause.cpp
+++ b/cryptominisat4/clause.cpp
@@ -4,8 +4,8 @@ using namespace CMSat;
 
 void ClauseUsageStats::print() const
 {
-    #ifdef STATS_NEEDED
     cout
+    #ifdef STATS_NEEDED
     << " lits visit: "
     << std::setw(8) << sumLitVisited/1000UL
     << "K"


### PR DESCRIPTION
If macro `STATS_NEEDED` is not defined, then the file does not correctly compile.
This change fixes the problem.
