### PR TITLE
Fix compilation under gcc 4.9 and clang 3.4 (both using libstdc++)

### DIFF
--- a/cryptominisat4/bva.cpp
+++ b/cryptominisat4/bva.cpp
@@ -25,6 +25,7 @@
 #include "clausecleaner.h"
 #include "subsumeimplicit.h"
 #include "sqlstats.h"
+#include <functional>
 
 using namespace CMSat;
 

--- a/cryptominisat4/reducedb.cpp
+++ b/cryptominisat4/reducedb.cpp
@@ -3,6 +3,7 @@
 #include "sqlstats.h"
 #include "clausecleaner.h"
 #include "completedetachreattacher.h"
+#include <functional>
 
 using namespace CMSat;
 


### PR DESCRIPTION
by adding missing include required for use of std::function
