### PR TITLE
Fix compilation on OS X

### DIFF
--- a/cryptominisat4/bva.cpp
+++ b/cryptominisat4/bva.cpp
@@ -25,6 +25,7 @@
 #include "clausecleaner.h"
 #include "subsumeimplicit.h"
 #include "sqlstats.h"
+#include <cmath>
 #include <functional>
 
 using namespace CMSat;


### PR DESCRIPTION
Removes the following errors when compiling on OS X:

/Users/rion/cryptominisat/cryptominisat4/bva.cpp:182:66: error: no member named
      'sqrt' in namespace 'std'; did you mean simply 'sqrt'?
    *simplifier->limit_to_decrease -= 2*(long)m_cls.size()*(long)std::sqrt(m...
                                                                 ^~~~~~~~~
                                                                 sqrt

/Users/rion/cryptominisat/cryptominisat4/bva.cpp:670:76: error: no member named
      'log' in namespace 'std'; did you mean simply 'log'?
  ...-= (double)potential.size()*(double)std::log(potential.size())*0.2;
                                         ^~~~~~~~
                                         log