### PR TITLE
link public against M4RI_LIBRARIES

### DIFF
--- a/cryptominisat4/CMakeLists.txt
+++ b/cryptominisat4/CMakeLists.txt
@@ -52,16 +52,8 @@ set(cryptoms_lib_link_libs "")
 if (M4RI_FOUND)
     include_directories(${M4RI_INCLUDE_DIRS})
 
-    if (STATICCOMPILE)
-        add_library(m4ri STATIC IMPORTED)
-    else (STATICCOMPILE)
-        add_library(m4ri SHARED IMPORTED)
-    endif (STATICCOMPILE)
-
-    set_property(TARGET m4ri PROPERTY IMPORTED_LOCATION ${M4RI_LIBRARIES})
-
     SET(cryptoms_lib_files ${cryptoms_lib_files} xorfinder.cpp)
-    SET(cryptoms_lib_link_libs ${cryptoms_lib_link_libs} m4ri)
+    SET(cryptoms_lib_link_libs ${cryptoms_lib_link_libs} ${M4RI_LIBRARIES})
 endif (M4RI_FOUND)
 
 if (MYSQL_FOUND AND STATS)
@@ -99,7 +91,7 @@ if (ALSO_BUILD_STATIC_LIB)
 endif()
 add_library(libcryptominisat4 SHARED ${cms_lib_objects})
 target_link_libraries(libcryptominisat4
-    ${cryptoms_lib_link_libs}
+    LINK_PUBLIC ${cryptoms_lib_link_libs}
 )
 set_target_properties(libcryptominisat4 PROPERTIES
     OUTPUT_NAME cryptominisat4


### PR DESCRIPTION
This way other CMake projects can pick up M4RI, even when it is installed locally.

Currently the imported target `m4ri` is exported, which will resolve to a locally installed m4ri library in `/usr/lib`, but will not work when m4ri is installed locally.
With this patch the full path to the library is exported.

This works, when m4ri, cryptominisat and the client using it (e.g. STP) are build on the same system but will fail when cryptominisat is packaged and used on a system with a different location. However currently this also only works when m4ri is installed system-wide on the new system.