### PR TITLE
Add option to disable Python in CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,17 +330,21 @@ add_subdirectory(src cmsat4-src)
 # -----------------------------------------------------------------------------
 # Look for python
 # -----------------------------------------------------------------------------
-find_package (PythonInterp 2.7)
-find_package (PythonLibs 2.7)
-if (PYTHON_EXECUTABLE AND PYTHON_LIBRARY AND PYTHON_INCLUDE_DIRS)
+option(ENABLE_PYTHON_INTERFACE "Enable Python interface" ON)
+
+if (ENABLE_PYTHON_INTERFACE)
+    find_package (PythonInterp 2.7)
+    find_package (PythonLibs 2.7)
+    if (PYTHON_EXECUTABLE AND PYTHON_LIBRARY AND PYTHON_INCLUDE_DIRS)
 #     message(STATUS "PYTHON_EXECUTABLE:FILEPATH=${PYTHON_EXECUTABLE}")
 #     message(STATUS "PYTHON_LIBRARY:FILEPATH=${PYTHON_LIBRARY}")
 #     message(STATUS "PYTHON_INCLUDE_DIR:FILEPATH=${PYTHON_INCLUDE_DIR}")
 #     message(STATUS "PYTHONLIBS_VERSION_STRING=${PYTHONLIBS_VERSION_STRING}")
-    message(STATUS "OK, found python interpreter, libs and header files -> building python plugin")
-    add_subdirectory(python py-lib)
-else()
-    message(WARNING "Cannot find python interpreter, libs and header files -> not building python plugin")
+        message(STATUS "OK, found python interpreter, libs and header files -> building python plugin")
+        add_subdirectory(python py-lib)
+    else()
+        message(WARNING "Cannot find python interpreter, libs and header files -> not building python plugin")
+    endif()
 endif()
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
I had trouble compiling the Python interface in my setup (it seemed to pick up a compile flag from the system Python that the clang I was using did not support). Since I'm not using Python, I ended up adding an option to the CMake build to disable it, which might be useful to other people as well.