### PR TITLE
python: partially fixed python build on OSX

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -43,7 +43,9 @@ def _init_posix(init):
         # FIXME raises hardening-no-fortify-functions lintian warning.
         else:
             # Non-Sun needs linkage with g++
-            config_vars['LDSHARED'] = 'g++ -shared -g -W -Wall -Wno-deprecated'
+            config_vars['CC'] = '${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS}'
+            config_vars['CXX'] = '${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS}'
+            config_vars['LDSHARED'] = '${CMAKE_CXX_COMPILER} -shared -g -W -Wall -Wno-deprecated'
 
         config_vars['CFLAGS'] = '-g -W -Wall -Wno-deprecated'
         config_vars['OPT'] = '-g -W -Wall -Wno-deprecated'
@@ -60,7 +62,7 @@ ext_kwds = dict(
     extra_compile_args = ['-I${PROJECT_SOURCE_DIR}', '-I${PROJECT_BINARY_DIR}/cmsat4-src'],
     language = "c++",
     library_dirs=['.', '/usr/local/lib', '${PROJECT_BINARY_DIR}/lib'],
-    libraries = ['cryptominisat4']
+    libraries = ['cryptominisat4', 'python']
 )
 
 setup(

--- a/src/solvertypesmini.h.in
+++ b/src/solvertypesmini.h.in
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #ifndef __SOLVERTYPESMINI_H__
 #define __SOLVERTYPESMINI_H__
 
-#if defined(_MSC_VER) || __cplusplus>=201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
+#if defined(_MSC_VER) || (__cplusplus>=201103L  && !defined(__clang__)) || (defined(__GXX_EXPERIMENTAL_CXX0X__)  && !defined(__clang__))
     #include <cstdint>
 #else
     #include <stdint.h>


### PR DESCRIPTION
 - Build is still broken because of linker issues
 - It seems setup.py compiles pycryptosat.cpp differently from the rest of the project