### PR TITLE
Fix unreachable code warnings

### DIFF
--- a/src/cnf.cpp
+++ b/src/cnf.cpp
@@ -449,10 +449,7 @@ void CNF::load_state(SimpleInFile& f)
 
 void CNF::test_all_clause_attached() const
 {
-#ifndef DEBUG_ATTACH_MORE
-    return;
-#endif
-
+#ifdef DEBUG_ATTACH_MORE
     for (vector<ClOffset>::const_iterator
         it = longIrredCls.begin(), end = longIrredCls.end()
         ; it != end
@@ -460,6 +457,7 @@ void CNF::test_all_clause_attached() const
     ) {
         assert(normClauseIsAttached(*it));
     }
+#endif
 }
 
 bool CNF::normClauseIsAttached(const ClOffset offset) const
@@ -476,10 +474,7 @@ bool CNF::normClauseIsAttached(const ClOffset offset) const
 
 void CNF::find_all_attach() const
 {
-    #ifndef SLOW_DEBUG
-    return;
-    #endif
-
+#ifdef SLOW_DEBUG
     for (size_t i = 0; i < watches.size(); i++) {
         const Lit lit = Lit::toLit(i);
         for (uint32_t i2 = 0; i2 < watches[i].size(); i2++) {
@@ -518,6 +513,7 @@ void CNF::find_all_attach() const
 
     find_all_attach(longIrredCls);
     find_all_attach(longRedCls);
+#endif
 }
 
 void CNF::find_all_attach(const vector<ClOffset>& cs) const
@@ -571,10 +567,7 @@ bool CNF::find_clause(const ClOffset offset) const
 
 void CNF::check_wrong_attach() const
 {
-    #ifndef SLOW_DEBUG
-    return;
-    #endif
-
+#ifdef SLOW_DEBUG
     for (vector<ClOffset>::const_iterator
         it = longRedCls.begin(), end = longRedCls.end()
         ; it != end
@@ -586,6 +579,7 @@ void CNF::check_wrong_attach() const
                 assert(cl[i-1].var() != cl[i].var());
         }
     }
+#endif
 }
 
 uint64_t CNF::count_lits(

--- a/src/searcher.cpp
+++ b/src/searcher.cpp
@@ -347,10 +347,10 @@ void Searcher::normalClMinim()
 
 void Searcher::debug_print_resolving_clause(const PropBy confl) const
 {
-    #ifndef DEBUG_RESOLV
-    return;
-    #endif
-
+#ifndef DEBUG_RESOLV
+    //Avoid unused parameter warning
+    (void) confl;
+#else
     switch(confl.getType()) {
         case tertiary_t: {
             cout << "resolv (tri): " << confl.lit2() << ", " << confl.lit3() << endl;
@@ -380,6 +380,7 @@ void Searcher::debug_print_resolving_clause(const PropBy confl) const
             break;
         }
     }
+#endif
 }
 
 void Searcher::update_clause_glue_from_analysis(Clause* cl)
@@ -658,14 +659,15 @@ Clause* Searcher::otf_subsume_last_resolved_clause(Clause* last_resolved_long_cl
 
 void Searcher::print_debug_resolution_data(const PropBy confl)
 {
-    #ifndef DEBUG_RESOLV
-    return;
-    #endif
-
+#ifndef DEBUG_RESOLV
+    //Avoid unused parameter warning
+    (void) confl;
+#else
     cout << "Before resolution, trail is: " << endl;
     print_trail();
     cout << "Conflicting clause: " << confl << endl;
     cout << "Fail bin lit: " << failBinLit << endl;
+#endif
 }
 
 Clause* Searcher::analyze_conflict(


### PR DESCRIPTION
When not using flags like DEBUG_RESOLV, some functions do nothing. This
was achieved by having an unconditional return in an `#ifndef`
statement. The return statement, however, makes the rest of the function
(intentionally) unreachable and triggers a warning when compiling with
clang. The solution is to restructure the affected functions slightly to
avoid these warnings.