### PR TITLE
Add missing include

### DIFF
--- a/src/searcher.cpp
+++ b/src/searcher.cpp
@@ -30,6 +30,7 @@
 #include "propbyforgraph.h"
 #include <algorithm>
 #include <cstddef>
+#include <math.h>
 #include "sqlstats.h"
 #include "datasync.h"
 #include "reducedb.h"


### PR DESCRIPTION
Looks like commit 5a40d1b9c3053c14e1f4bfd6b92326b415ebdfec broke the
build on clang by indirectly removing math.h from the included header files.