### PR TITLE
Fix python build on OSX

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,3 +1,5 @@
+execute_process(COMMAND python-config --cflags OUTPUT_VARIABLE PY_C_CONFIG)
+execute_process(COMMAND python-config --ldflags OUTPUT_VARIABLE PY_LD_CONFIG)
 set(SETUP_PY_IN "${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in")
 set(SETUP_PY    "${CMAKE_CURRENT_BINARY_DIR}/setup.py")
 set(OUTPUT      "${CMAKE_CURRENT_BINARY_DIR}/build")

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -57,9 +57,10 @@ ext_kwds = dict(
     name = "pycryptosat",
     sources = ["${CMAKE_CURRENT_SOURCE_DIR}/pycryptosat.cpp"],
     define_macros = [],
-    extra_compile_args = ['-I${PROJECT_SOURCE_DIR}', '-I${PROJECT_BINARY_DIR}/cmsat4-src'],
+    extra_compile_args = """${PY_C_CONFIG}""".rstrip().split(" ") + ['-I${PROJECT_SOURCE_DIR}', '-I${PROJECT_BINARY_DIR}/cmsat4-src'],
+    extra_link_args = """${PY_LD_CONFIG}""".rstrip().split(" "),
     language = "c++",
-    library_dirs=['.', '/usr/local/lib', '${PROJECT_BINARY_DIR}/lib'],
+    library_dirs=['.', '${PROJECT_BINARY_DIR}/lib'],
     libraries = ['cryptominisat4']
 )
 


### PR DESCRIPTION
Use python-config to get the correct parameters for building/linking.
Limitation: flags returned by python-config cannot contain spaces
because spaces are used to split the flags.