### PR TITLE
Only attempt coveralls upload if $COVERTOKEN set

### DIFF
--- a/scripts/travis-cmake.sh
+++ b/scripts/travis-cmake.sh
@@ -244,5 +244,9 @@ if [ "$CMS_CONFIG" = "COVERAGE" ]; then
 
   # debug before upload
   lcov --list coverage.info
-  coveralls-lcov --repo-token $COVERTOKEN coverage.info # uploads to coveralls
+
+  # only attempt upload if $COVERTOKEN is set
+  if [ -n "$COVERTOKEN" ]; then
+    coveralls-lcov --repo-token $COVERTOKEN coverage.info # uploads to coveralls
+  fi
 fi


### PR DESCRIPTION
Travis fails for pull requests because CMS_CONFIG=COVERAGE uses
$COVERTOKEN when uploading results to coveralls and $COVERTOKEN is not set.
Check if $COVERTOKEN is set and skip the result upload if it is not.