### PR TITLE
Fix while loop condition in skipWhitespace()

### DIFF
--- a/src/streambuffer.h
+++ b/src/streambuffer.h
@@ -82,7 +82,7 @@ public:
     void skipWhitespace()
     {
         char c = value();
-        while (c == '\n' || c == '\r' || c == ' ') {
+        while (c == '\t' || c == '\r' || c == ' ') {
             advance();
             c = value();
         }


### PR DESCRIPTION
Commit f10db78e23dd180abcab74f4e7d1beef99035e89 changed the while loop
condition slightly (accepting '\n' instead of '\t'), leading to failing
tests.