### PR TITLE
Interface extension for glue manipulation

### DIFF
--- a/src/cryptominisat.cpp
+++ b/src/cryptominisat.cpp
@@ -418,6 +418,16 @@ DLL_PUBLIC void SATSolver::set_no_bva()
     }
 }
 
+DLL_PUBLIC void SATSolver::append_glue_calc(uint32_t (*function)(vector<Lit>&, uint32_t))
+{
+    for (size_t i = 0; i < data->solvers.size(); ++i) {
+        Solver& s = *data->solvers[i];
+        s.conf.do_bva = false;
+        s.conf.doRenumberVars = false;
+        s.conf.calc_glue_user = function;
+    }
+}
+
 DLL_PUBLIC void SATSolver::set_verbosity(unsigned verbosity)
 {
   for (size_t i = 0; i < data->solvers.size(); ++i) {

--- a/src/cryptominisat.h.in
+++ b/src/cryptominisat.h.in
@@ -74,6 +74,7 @@ namespace CMSat {
         void set_no_simplify_at_startup();
         void set_no_equivalent_lit_replacement();
         void set_no_bva();
+        void append_glue_calc(uint32_t (*function)(std::vector<Lit>&, uint32_t));
 
         //Get info
         static const char* get_version();

--- a/src/searcher.cpp
+++ b/src/searcher.cpp
@@ -763,6 +763,9 @@ Clause* Searcher::analyze_conflict(
         }
     }
     glue = calc_glue(learnt_clause);
+    if (conf.calc_glue_user != NULL) {
+      glue = conf.calc_glue_user(learnt_clause, glue);
+    }
     print_fully_minimized_learnt_clause();
 
     if (learnt_clause.size() > conf.max_size_more_minim

--- a/src/solverconf.cpp
+++ b/src/solverconf.cpp
@@ -91,6 +91,7 @@ DLL_PUBLIC SolverConf::SolverConf() :
         //Glues
         , update_glues_on_prop(false)
         , update_glues_on_analyze(true)
+        , calc_glue_user(NULL)
 
         //OTF
         , otfHyperbin      (true)

--- a/src/solverconf.h
+++ b/src/solverconf.h
@@ -24,13 +24,17 @@ THE SOFTWARE.
 #define SOLVERCONF_H
 
 #include <string>
+#include <vector>
 #include <cstdlib>
 #include <cassert>
 #include "gaussianconfig.h"
 
 using std::string;
+using std::vector;
 
 namespace CMSat {
+
+class Lit;
 
 enum class ClauseClean {
     glue = 0
@@ -209,6 +213,7 @@ class SolverConf
         //Glues
         int       update_glues_on_prop;
         int       update_glues_on_analyze;
+        uint32_t  (*calc_glue_user)(vector<Lit>&, uint32_t);
 
         //OTF stuff
         int       otfHyperbin;
@@ -344,15 +349,15 @@ class SolverConf
         double global_timeout_multiplier;
         double global_timeout_multiplier_multiplier;
         double global_multiplier_multiplier_max;
-        unsigned  maxDumpRedsSize; ///<When dumping the redundant clauses, this is the maximum clause size that should be dumped
+        unsigned maxDumpRedsSize; ///<When dumping the redundant clauses, this is the maximum clause size that should be dumped
         unsigned origSeed;
         unsigned long long sync_every_confl;
         unsigned reconfigure_val;
         unsigned reconfigure_at;
         unsigned preprocess;
-        std::string simplified_cnf;
-        std::string solution_file;
-        std::string saved_state_file;
+        string simplified_cnf;
+        string solution_file;
+        string saved_state_file;
 };
 
 } //end namespace


### PR DESCRIPTION
As in #320 suggested I added code to add a function for glue manipulation without changing CMS code. There is an example for usage below. Maybe you like to merge.
```
uint32_t manipulate(vector<Lit>& clause, uint32_t glue) {
    // Accept and pass glue or change it
    return glue;
}
solver.append_glue_calc(manipulate);
```