### PR TITLE
Support for model counting under projection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ scripts/fuzz/tmp_for_xor_to_cnf_*
 scripts/reconf/outfile*
 
 web/jquery-1.11.3.min.js
+build

--- a/src/cryptominisat.h.in
+++ b/src/cryptominisat.h.in
@@ -32,6 +32,7 @@ THE SOFTWARE.
 #include <utility>
 #include <atomic>
 #include "cryptominisat5/solvertypesmini.h"
+#include <set>
 
 namespace CMSat {
     struct CMSatPrivateData;
@@ -46,6 +47,7 @@ namespace CMSat {
         , std::atomic<bool>* interrupt_asap = NULL
         );
         ~SATSolver();
+        void set_num_threads(unsigned n);
         unsigned nVars() const;
         bool add_clause(const std::vector<Lit>& lits);
         bool add_xor_clause(const std::vector<unsigned>& vars, bool rhs);
@@ -97,8 +99,15 @@ namespace CMSat {
 
         std::vector<Lit> get_zero_assigned_lits() const;
         std::vector<std::pair<Lit, Lit> > get_all_binary_xors() const;
+
+
+        //projection variables (remembering) for model couting
+        bool has_projection_scope() const { return ! projection_scope.empty(); }
+        void set_projection_scope(const std::set<uint32_t> ps) { projection_scope = ps;}
+        std::set<uint32_t> get_projection_scope() const { return projection_scope;}
     private:
         CMSatPrivateData *data;
+        std::set<uint32_t> projection_scope;
     };
 }
 

--- a/src/cryptominisat.h.in
+++ b/src/cryptominisat.h.in
@@ -47,7 +47,6 @@ namespace CMSat {
         , std::atomic<bool>* interrupt_asap = NULL
         );
         ~SATSolver();
-        void set_num_threads(unsigned n);
         unsigned nVars() const;
         bool add_clause(const std::vector<Lit>& lits);
         bool add_xor_clause(const std::vector<unsigned>& vars, bool rhs);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1266,14 +1266,8 @@ lbool Main::multi_solutions()
     while(current_nr_of_solutions < max_nr_of_solutions && ret == l_True) {
         ret = solver->solve();
 
-        //BUG: this should a bug here:
-        // If current clauses are unsat we are counting up, line should be moved
-        // into the next then branch
-        current_nr_of_solutions++;
-
         if (ret == l_True && current_nr_of_solutions < max_nr_of_solutions) {
-
-            //current_nr_of_solutions++;
+            current_nr_of_solutions++;
 
             printResultFunc(&cout, false, ret);
             if (resultfile) {
@@ -1316,6 +1310,5 @@ lbool Main::multi_solutions()
         }
     }
 
-    std::cout << current_nr_of_solutions << std::endl;
     return ret;
 }

--- a/src/streambuffer.h
+++ b/src/streambuffer.h
@@ -145,7 +145,7 @@ public:
         }
         if (c < '0' || c > '9') {
             std::cerr
-            << "PARSE ERROR! Unexpected char (dec: '" << c << ")"
+            << "PARSE ERROR! Unexpected char (dec: '" << (int) c << "')"
             << " At line " << lineNum
             << " we expected a number"
             << std::endl;


### PR DESCRIPTION
This patch extends cryptominsat to support for model counting under projection.

This patch contains: 
* Modification of dimacsparser to support `cr [...]  0` lines
* Extension of `multi_solutions` for projection scope  

After the patch CM successfully counts 32 of following input: 

```
p cnf 10 0 
cr 1 2 3 4 5 0 
```