### PR TITLE
Put -I flag for generated headers earlier in the command line.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,11 +2,11 @@ include_directories(
     ${PROJECT_SOURCE_DIR}
 )
 
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
 if(Boost_FOUND)
     include_directories(${Boost_INCLUDE_DIRS})
 endif()
-
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/GitSHA1.cpp.in" "${CMAKE_CURRENT_BINARY_DIR}/GitSHA1.cpp" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cryptominisat.h.in" "${CMAKE_CURRENT_BINARY_DIR}/cryptominisat5/cryptominisat.h" @ONLY)


### PR DESCRIPTION
Otherwise, compiler may pick headers from installed cmsat.