### PR TITLE
Update clauseallocator.cpp

### DIFF
--- a/src/clauseallocator.cpp
+++ b/src/clauseallocator.cpp
@@ -186,7 +186,7 @@ void ClauseAllocator::clauseFree(Clause* cl)
     if (!quick_freed) {
         cl->setFreed();
         uint64_t est_num_cl = cl->size();
-        est_num_cl = std::max(est_num_cl, (size_t)3); //we sometimes allow gauss to allocate 3-long clauses
+        est_num_cl = std::max(est_num_cl, (uint64_t)3); //we sometimes allow gauss to allocate 3-long clauses
         uint64_t bytes_freed = sizeof(Clause) + est_num_cl*sizeof(Lit);
         uint64_t elems_freed = bytes_freed/sizeof(BASE_DATA_TYPE) + (bool)(bytes_freed % sizeof(BASE_DATA_TYPE));
         currentlyUsedSize -= elems_freed;


### PR DESCRIPTION
max(a,b) is only defined, when a and b have the same type. I made a type cast for that. The project is not compilable in mac (clang) else.