### PR TITLE
Replace dependency on XXD with simple Python script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,11 @@ if(NOT (CMAKE_MAJOR_VERSION LESS 2))
 endif()
 
 # -----------------------------------------------------------------------------
+# Provide scripts dir for included cmakes to use
+# -----------------------------------------------------------------------------
+set(CRYPTOMS_SCRIPTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/scripts)
+
+# -----------------------------------------------------------------------------
 # Make RelWithDebInfo the default build type if otherwise not set
 # -----------------------------------------------------------------------------
 set(build_types Debug Release RelWithDebInfo MinSizeRel)

--- a/scripts/xxd-alike.py
+++ b/scripts/xxd-alike.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import sys
+
+PY3 = sys.version_info.major == 3
+
+input_name = sys.argv[1]
+output_path = sys.argv[2]
+output_name = input_name.replace('.', '_')
+
+# In python 3, opening file as rb will return bytes and iteration is per byte
+# In python 2, opening file as rb will return string and iteration is per char
+# and char need to be converted to bytes.
+# This function papers over the differences
+def convert(c):
+    if PY3:
+        return c
+    return ord(c)
+
+with open(input_name, 'rb') as file:
+    contents = file.read()
+with open(output_path, 'w') as out:
+    out.write('unsigned char {}[] = {{'.format(output_name))
+    first = True
+    for i, byte in enumerate(contents):
+        if not first:
+            out.write(', ')
+        first = False
+        if i % 12 == 0:
+            out.write('\n  ')
+        out.write('0x{:02x}'.format(convert(byte)))
+    out.write('\n};\n')
+    out.write('unsigned int {}_len = {};\n'.format(output_name, len(contents)))

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,7 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cryptominisat_c.h.in" "${CMAKE_CURRE
 add_custom_command(
     OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/sql_tablestructure.cpp
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    COMMAND xxd -i cmsat_tablestructure.sql ${CMAKE_CURRENT_BINARY_DIR}/sql_tablestructure.cpp
+    COMMAND ${CRYPTOMS_SCRIPTS_DIR}/xxd-alike.py cmsat_tablestructure.sql ${CMAKE_CURRENT_BINARY_DIR}/sql_tablestructure.cpp
     DEPENDS ${CMAKE_SOURCE_DIR}/cmsat_tablestructure.sql
 )
 


### PR DESCRIPTION
Python runtime is more common on Windows than Vim (on Linux its a wash), so I suggest trading dependency on vim for dependency on Python runtime. This PR implements required part of xxd in Python and is Python 2 and Python 3 compatible.

This could also likely be implemented in CMake, but not by me.

Related to #406 