### PR TITLE
Fix const placement in ReduceDB::get_total_time()

### DIFF
--- a/src/reducedb.h
+++ b/src/reducedb.h
@@ -34,7 +34,7 @@ class ReduceDB
 {
 public:
     ReduceDB(Solver* solver);
-    const double get_total_time() {
+    double get_total_time() const {
         return total_time;
     }
     void handle_lev1();


### PR DESCRIPTION
`const double` as a return type makes no sense and the method is const, so I moved it around to silence a warning from gcc.