### PR TITLE
Enable W4 when compiling with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,8 +216,14 @@ else()
     # buffers security check
     add_compile_options(/GS)
 
-    # not too many warnings
-    add_compile_options(/W1)
+    # Proper warning level
+    add_compile_options(/W4)
+    # Disable STL used in DLL-boundary warning
+    add_compile_options(/wd4251)
+    add_compile_options(/D_CRT_SECURE_NO_WARNINGS)
+
+    # Wall is MSVC's Weverything, so annoying unless used from the start
+    # and with judiciously used warning disables
     # add_compile_options(/Wall)
 
     # /Za = only ansi C98 & C++11

--- a/src/bva.cpp
+++ b/src/bva.cpp
@@ -507,8 +507,8 @@ bool BVA::add_longer_clause(const Lit new_lit, const OccurClause& cl)
             lits.resize(2);
             lits[0] = new_lit;
             lits[1] = cl.ws.lit2();
-            Clause* cl = solver->add_clause_int(lits, false, ClauseStats(), false, &lits, true, new_lit);
-            assert(cl == NULL);
+            Clause* cl_check = solver->add_clause_int(lits, false, ClauseStats(), false, &lits, true, new_lit);
+            assert(cl_check == NULL);
             break;
         }
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -27,6 +27,19 @@ THE SOFTWARE.
 #include <cstdlib>
 #include <stdio.h>
 
+#if defined(_MSC_VER)
+#define release_assert(a) \
+    do { \
+    __pragma(warning(push)) \
+    __pragma(warning(disable:4127)) \
+        if (!(a)) {\
+    __pragma(warning(pop)) \
+            fprintf(stderr, "*** ASSERTION FAILURE in %s() [%s:%d]: %s\n", \
+            __FUNCTION__, __FILE__, __LINE__, #a); \
+            abort(); \
+        } \
+    } while (0)
+#else
 #define release_assert(a) \
     do { \
         if (!(a)) {\
@@ -35,9 +48,10 @@ THE SOFTWARE.
             abort(); \
         } \
     } while (0)
+#endif
 
 #if !defined(__GNUC__) && !defined(__clang__)
-#define __builtin_prefetch(x)
+#define __builtin_prefetch(x) (void)(x)
 #endif //__GNUC__
 
 //We shift stuff around in Watched, so not all of 32 bits are useable.

--- a/src/features_to_reconf.cpp
+++ b/src/features_to_reconf.cpp
@@ -31,7 +31,7 @@ namespace CMSat {
 double get_score0(const SolveFeatures& feat, const int verb);
 double get_score7(const SolveFeatures& feat, const int verb);
 
-int get_reconf_from_features(const SolveFeatures& feat, const int verb)
+int get_reconf_from_features(const SolveFeatures& /*feat*/, const int /*verb*/)
 {
 	return 0;
 }

--- a/src/ipasir.cpp
+++ b/src/ipasir.cpp
@@ -198,8 +198,8 @@ DLL_PUBLIC int ipasir_failed (void * solver, int lit)
     const vector<Lit>& confl = s->solver->get_conflict();
     const Lit tofind(std::abs(lit)-1, lit < 0);
 
-    for(const Lit lit: confl) {
-        if (lit == tofind) {
+    for(const Lit l: confl) {
+        if (l == tofind) {
             return true;
         }
     }
@@ -219,14 +219,14 @@ DLL_PUBLIC int ipasir_failed (void * solver, int lit)
  * Required state: INPUT or SAT or UNSAT
  * State after: INPUT or SAT or UNSAT
  */
-DLL_PUBLIC void ipasir_set_terminate (void * /*solver*/, void * /*state*/, int (*terminate)(void * state))
+DLL_PUBLIC void ipasir_set_terminate (void * /*solver*/, void * /*state*/, int (* /*terminate*/)(void * state))
 {
     //this is complicated.
 }
 
 }
 
-DLL_PUBLIC void ipasir_set_learn (void * solver, void * state, int max_length, void (*learn)(void * state, int * clause))
+DLL_PUBLIC void ipasir_set_learn (void * /*solver*/, void * /*state*/, int /*max_length*/, void (* /*learn*/)(void * state, int * clause))
 {
     //this is complicated
 }

--- a/src/main_simple.cpp
+++ b/src/main_simple.cpp
@@ -39,6 +39,12 @@ using std::endl;
 #include "cryptominisat5/cryptominisat.h"
 #include "dimacsparser.h"
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4706) // Assignment within conditional expression
+                              // -- used in parsing args
+#endif
+
 using namespace CMSat;
 std::ostream* dratf;
 
@@ -285,3 +291,7 @@ int main(int argc, char** argv)
         return ret == l_True ? 10 : 20;
     }
 }
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif

--- a/src/occsimplifier.cpp
+++ b/src/occsimplifier.cpp
@@ -1414,8 +1414,8 @@ size_t OccSimplifier::rem_cls_from_watch_due_to_varelim(
                 lits.resize(cl.size());
                 std::copy(cl.begin(), cl.end(), lits.begin());
                 add_clause_to_blck(lit, lits);
-                for(Lit lit: lits) {
-                    touched.touch(lit);
+                for(Lit l: lits) {
+                    touched.touch(l);
                 }
             } else {
                 red = true;

--- a/src/searcher.cpp
+++ b/src/searcher.cpp
@@ -3077,7 +3077,7 @@ void Searcher::read_long_cls(
         tmp_cl.clear();
 
         uint32_t sz = f.get_uint32_t();
-        for(size_t i = 0; i < sz; i++)
+        for(size_t j = 0; i < sz; i++)
         {
             tmp_cl.push_back(f.get_lit());
         }

--- a/src/searcher.h
+++ b/src/searcher.h
@@ -481,7 +481,7 @@ inline void Searcher::bumpClauseAct(Clause* cl)
     if (cl->stats.activity > 1e20 ) {
         // Rescale
         for(ClOffset offs: longRedCls[2]) {
-            cl_alloc.ptr(offs)->stats.activity *= 1e-20;
+            cl_alloc.ptr(offs)->stats.activity *= static_cast<float>(1e-20);
         }
         cla_inc *= 1e-20;
     }

--- a/src/simplefile.h
+++ b/src/simplefile.h
@@ -32,7 +32,6 @@ using std::ios;
 #include "solvertypes.h"
 
 namespace CMSat {
-using namespace CMSat;
 
 class SimpleOutFile
 {


### PR DESCRIPTION
Also fixes most of the resulting warnings. There are some 30 warnings
left, but they should be easy to fix with some mechanical work.