### PR TITLE
Correct loop iterator name

### DIFF
--- a/src/searcher.cpp
+++ b/src/searcher.cpp
@@ -3077,7 +3077,7 @@ void Searcher::read_long_cls(
         tmp_cl.clear();
 
         uint32_t sz = f.get_uint32_t();
-        for(size_t j = 0; i < sz; i++)
+        for(size_t j = 0; j < sz; j++)
         {
             tmp_cl.push_back(f.get_lit());
         }


### PR DESCRIPTION
There was a typo in a loop iterator name which was introduced recently. (#411)