### PR TITLE
Reduce number of MSVC warnings

### DIFF
--- a/src/cnf.h
+++ b/src/cnf.h
@@ -514,6 +514,7 @@ inline void CNF::check_no_removed_or_freed_cl_in_watch() const
             Clause& cl = *cl_alloc.ptr(w.get_offset());
             assert(!cl.getRemoved());
             assert(!cl.freed());
+            (void) cl;
         }
     }
 }

--- a/src/watched.h
+++ b/src/watched.h
@@ -175,6 +175,7 @@ class Watched {
             assert(red());
             #endif
             assert(toSet == false);
+            (void) toSet;
             data2 &= (~(1U));
         }
 

--- a/src/xorfinder.h
+++ b/src/xorfinder.h
@@ -103,7 +103,7 @@ class PossibleXor
             }
 
             foundComb.clear();
-            foundComb.resize(1UL<<size, false);
+            foundComb.resize(1ULL<<size, false);
             foundComb[whichOne] = true;
         }
         uint32_t NumberOfSetBits(uint32_t i) const;


### PR DESCRIPTION
This fixes some 200 of the new warnings. After the ones originating in cnf-utils submodule are fixed, I intend to go through the remaining ones again and see how much is there left.

Related to #419 and #411 