### PR TITLE
Fix warnings: long vs. double, extra semicolon in class definition.

### DIFF
--- a/python/src/pycryptosat.cpp
+++ b/python/src/pycryptosat.cpp
@@ -98,7 +98,7 @@ static SATSolver* setup_solver(PyObject *args, PyObject *kwds)
 
     int verbose = 0;
     int num_threads = 1;
-    long time_limit = std::numeric_limits<double>::max();
+    double time_limit = std::numeric_limits<double>::max();
     long confl_limit = std::numeric_limits<long>::max();
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|idli", kwlist, &verbose, &time_limit, &confl_limit, &num_threads)) {
         return NULL;
@@ -108,7 +108,7 @@ static SATSolver* setup_solver(PyObject *args, PyObject *kwds)
         return NULL;
     }
     if (time_limit < 0) {
-        PyErr_SetString(PyExc_ValueError, "timelimit must be at least 0");
+        PyErr_SetString(PyExc_ValueError, "time_limit must be at least 0");
         return NULL;
     }
     if (confl_limit < 0) {

--- a/src/occsimplifier.h
+++ b/src/occsimplifier.h
@@ -59,7 +59,7 @@ class BVA;
 
 struct BlockedClauses {
     BlockedClauses()
-    {};
+    {}
 
     explicit BlockedClauses(size_t _start, size_t _end) :
         start(_start)


### PR DESCRIPTION
- In the earlier pull request #478, the `time_limit` was updated from long->double in nearly ever case except [one](https://github.com/msoos/cryptominisat/pull/478/files#diff-437bd5e874df2ba9f9ced39b13eee9abR101). This also fixes the inconsistent use of `time_limit` versus `timelimit` in the [error string](https://github.com/msoos/cryptominisat/pull/478/files#diff-437bd5e874df2ba9f9ced39b13eee9abR111).
- Fixes a new [GCC](https://gcc.gnu.org/ml/gcc-patches/2017-04/msg00469.html)/Clang warning about `-Wextra-semi` in the occ simplifier code. 

Ran the test cases locally and it builds and passes, but not sure if Python gets tested. :)