### PR TITLE
Surpress -Wclass-memaccess from Vec.h

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ if (NOT WIN32)
     endif()
 
     add_cxx_flag_if_supported("-Wno-bitfield-constant-conversion")
+    add_cxx_flag_if_supported("-Wno-class-memaccess")
     #add_cxx_flag_if_supported("-Wduplicated-cond")
     #add_cxx_flag_if_supported("-Wduplicated-branches")
     add_cxx_flag_if_supported("-Wlogical-op")


### PR DESCRIPTION
Pull request in case you want to suppress the warning from #479. Performs it for all files in `src` -- if you prefer, I can figure out how to do it locally in `Vec.h`. 

Built it and tested it (`make test`) and the compile warnings do go away. :)

Signed-off-by: Alexander Scheel <alexander.m.scheel@gmail.com>