### PR TITLE
Fix DESTDIR support for installing the Python module

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -74,7 +74,7 @@ add_custom_target(python_interface_dist_package
                   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 install(CODE "execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} install --record files.txt
+    COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} install --root=\$ENV{DESTDIR} --record files.txt
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})"
 )
 


### PR DESCRIPTION
CMake normally supports `DESTDIR` installation of files--this is used (typically by running something like `make install DESTDIR=some/tmp/dir`) to install packages into an alternate root, usually for packaging purposes.

However, when packaging cryptominisat the Python module is not installed into a supplied `DESTDIR`.  This could be worked around in principle by disabling CMake from installing the Python module, and supplying the necessary commands manually.  But better to just fix this directly.  This solution worked for me.