### PR TITLE
Fix man page install location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,7 +436,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
             INSTALL(
                 FILES ${CMAKE_CURRENT_BINARY_DIR}/cryptominisat5.1
-                DESTINATION ${CMAKE_INSTALL_PREFIX}/man/man1)
+                DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man/man1)
         endif()
         ADD_CUSTOM_TARGET(man_cms5_simple
             ALL
@@ -451,7 +451,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
         INSTALL(
             FILES ${CMAKE_CURRENT_BINARY_DIR}/cryptominisat5_simple.1
-            DESTINATION ${CMAKE_INSTALL_PREFIX}/man/man1)
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man/man1)
 
         message(STATUS "Manpage will be created and installed")
     else()


### PR DESCRIPTION
Under 5.6.0, cmake configures the destination for the man pages to be `$PREFIX/man/`; however, man pages usually reside in `$PREFIX/share/man`. See FILES in `man man` ([here](http://man.he.net/?topic=man&section=all)).