### PR TITLE
Fix DESTDIR support for the Python package again

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -61,7 +61,7 @@ add_custom_target(python_interface
                   ALL DEPENDS ${OUTPUT}/timestamp)
 
 install(CODE "execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} install --prefix=${CMAKE_INSTALL_PREFIX} --record files.txt
+    COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} install --root=\$ENV{DESTDIR} --prefix=${CMAKE_INSTALL_PREFIX} --record files.txt
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})"
 )
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -61,7 +61,7 @@ add_custom_target(python_interface
                   ALL DEPENDS ${OUTPUT}/timestamp)
 
 install(CODE "execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} install --root=\$ENV{DESTDIR} --prefix=${CMAKE_INSTALL_PREFIX} --record files.txt
+    COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} install --root=\$ENV{DESTDIR}/ --prefix=${CMAKE_INSTALL_PREFIX} --record files.txt
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})"
 )
 


### PR DESCRIPTION
Fixes regression against #490 introduced by 63a629f5e363a467abff1fa29becf42fe55b79f9 and b3cd73f369d4ea14f12824f0f3c4a06a9aa0e1b1 `CMAKE_INSTALL_PREFIX` is *not* the same thing as `DESTDIR`, and `--prefix` is not the same thing as `--root` (though both can coexist).

The installation path ends up being `<root><prefix>/<libdir>/<pythonX.Y>/site-packages/`.  By default root is normally `/` but the point of `DESTDIR` is to change that to an alternate path (e.g. for packaging).
