### PR TITLE
Fixes in manpage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,7 +441,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
             ADD_CUSTOM_COMMAND(
                 TARGET man_cms5
                 COMMAND help2man
-                ARGS --version-string=${CMS_FULL_VERSION} --help-option="--hhelp" $<TARGET_FILE:cryptominisat5> -o ${CMAKE_CURRENT_BINARY_DIR}/cryptominisat5.1
+                ARGS --version-string=${CMS_FULL_VERSION} --help-option="--hhelp" $<TARGET_FILE:cryptominisat5> --include=${CMAKE_CURRENT_SOURCE_DIR}/docs/help2man.include --no-info -o ${CMAKE_CURRENT_BINARY_DIR}/cryptominisat5.1
             )
 
             INSTALL(
@@ -458,7 +458,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
         ADD_CUSTOM_COMMAND(
             TARGET man_cms5_simple
             COMMAND help2man
-            ARGS --version-string=${CMS_FULL_VERSION} --help-option="-h" $<TARGET_FILE:cryptominisat5_simple> -o ${CMAKE_CURRENT_BINARY_DIR}/cryptominisat5_simple.1
+            ARGS --version-string=${CMS_FULL_VERSION} --help-option="-h" $<TARGET_FILE:cryptominisat5_simple> --include=${CMAKE_CURRENT_SOURCE_DIR}/docs/help2man.include --no-info -o ${CMAKE_CURRENT_BINARY_DIR}/cryptominisat5_simple.1
         )
 
         INSTALL(

--- a/docs/help2man.include
+++ b/docs/help2man.include
@@ -1,0 +1,7 @@
+[authors]
+.B cryptominisat
+was primarily written by Mate Soos.
+[see also]
+Full documentation for the
+.B cryptominisat
+suite can be found at https://www.msoos.org/cryptominisat5/


### PR DESCRIPTION
we don't have an info page so we should not claim to have one. Also, an AUTHORS and SEE ALSO section are recommended by Debian.
```diff
@@ -527,15 +527,10 @@
 .SS "Preproc run schedule:"
 .IP
 handle\-comps,scc\-vrepl, cache\-clean, cache\-tryboth,sub\-impl,sub\-str\-cls\-with\-bin, distill\-cls, scc\-vrepl, sub\-impl,occ\-backw\-sub\-str, occ\-xor, occ\-clean\-implicit, occ\-bve, occ\-bva,str\-impl, cache\-clean, sub\-str\-cls\-with\-bin, distill\-cls, scc\-vrepl, sub\-impl,str\-impl, sub\-impl, sub\-str\-cls\-with\-bin,intree\-probe, probe,must\-renumber
+.SH AUTHORS
+.B cryptominisat
+was primarily written by Mate Soos.
 .SH "SEE ALSO"
-The full documentation for
-.B cryptominisat5
-is maintained as a Texinfo manual.  If the
-.B info
-and
-.B cryptominisat5
-programs are properly installed at your site, the command
-.IP
-.B info cryptominisat5
-.PP
-should give you access to the complete manual.
+Full documentation for the
+.B cryptominisat
+suite can be found at https://www.msoos.org/cryptominisat5/
```