### PR TITLE
Update README to reflect zlib dependency

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -75,7 +75,7 @@ To build and install, issue:
 ```
 sudo apt-get install build-essential cmake
 # not required but very useful
-sudo apt-get install libzip-dev libboost-program-options-dev libm4ri-dev libsqlite3-dev
+sudo apt-get install zlib1g-dev libboost-program-options-dev libm4ri-dev libsqlite3-dev
 tar xzvf cryptominisat-version.tar.gz
 cd cryptominisat-version
 mkdir build && cd build
@@ -200,7 +200,7 @@ The python module works with both Python 2 and Python 3. It must be compiled as 
 
 ```
 sudo apt-get install build-essential cmake
-sudo apt-get install libzip-dev libboost-program-options-dev libm4ri-dev libsqlite3-dev
+sudo apt-get install zlib1g-dev libboost-program-options-dev libm4ri-dev libsqlite3-dev
 sudo apt-get install python3-setuptools python3-dev
 tar xzvf cryptominisat-version.tar.gz
 cd cryptominisat-version
@@ -373,7 +373,7 @@ s SATISFIABLE
 v [solution] 0
 ```
 
-or 
+or
 
 ```
 s UNSATISFIABLE
@@ -397,7 +397,7 @@ For building with Gaussian Elimination, you need to build as per:
 
 ```
 sudo apt-get install build-essential cmake
-sudo apt-get install libzip-dev libboost-program-options-dev libm4ri-dev libsqlite3-dev
+sudo apt-get install zlib1g-dev libboost-program-options-dev libm4ri-dev libsqlite3-dev
 tar xzvf cryptominisat-version.tar.gz
 cd cryptominisat-version
 mkdir build && cd build
@@ -432,7 +432,7 @@ For testing you will need the GIT checkout and build as per:
 
 ```
 sudo apt-get install build-essential cmake git
-sudo apt-get install libzip-dev libboost-program-options-dev libm4ri-dev libsqlite3-dev
+sudo apt-get install zlib1g-dev libboost-program-options-dev libm4ri-dev libsqlite3-dev
 sudo apt-get install git python3-pip python3-setuptools python3-dev
 sudo pip3 install --upgrade pip
 sudo pip3 install lit


### PR DESCRIPTION
Dropped when #493 was closed were changes to the README for Ubuntu. Your (admittedly old) Debian [control](https://github.com/msoos/cryptominisat/blob/bf3ec2968e488e5d4c31da08d27e5e2dda4c3d1d/debian/control#L5) listed zlib as a dependency as does the Fedora [spec](https://src.fedoraproject.org/rpms/cryptominisat/blob/master/f/cryptominisat.spec#_21). 

(Other than that, I'm fine with dropping the Fedora-specific changes to the README).

Thanks!