### PR TITLE
[WIP][PoC][testing] Python array.array interface

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -131,7 +131,7 @@ modules = dict(
     language = "c++",
     library_dirs=['.', '${PROJECT_BINARY_DIR}/lib'],
     runtime_library_dirs=['${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}'],
-    libraries = ['libname']
+    libraries = [libname]
 )
 
 setup(

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -117,6 +117,11 @@ extra_link_args = list(ldconf)
 if platform.system() == 'Darwin':
     extra_link_args.append('-Wl,-rpath,'+"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
+if platform.system() == 'Windows':
+    libname = "cryptominisat5win"
+else:
+    libname = "cryptominisat5"
+
 modules = dict(
     name = "pycryptosat",
     sources = ["${CMAKE_CURRENT_SOURCE_DIR}/src/pycryptosat.cpp"],
@@ -126,7 +131,7 @@ modules = dict(
     language = "c++",
     library_dirs=['.', '${PROJECT_BINARY_DIR}/lib'],
     runtime_library_dirs=['${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}'],
-    libraries = ['cryptominisat5']
+    libraries = ['libname']
 )
 
 setup(

--- a/python/src/pycryptosat.cpp
+++ b/python/src/pycryptosat.cpp
@@ -471,7 +471,9 @@ static PyObject* add_clauses(Solver *self, PyObject *args, PyObject *kwds)
     while ((clause = PyIter_Next(iterator)) != NULL) {
         PyObject *arglist = Py_BuildValue("(O)", clause);
         PyObject *ret = add_clause(self, arglist, NULL);
-        Py_DECREF(ret);
+        if (ret) {
+            Py_DECREF(ret);
+        }
 
         /* release reference when done */
         Py_DECREF(arglist);

--- a/python/src/pycryptosat.cpp
+++ b/python/src/pycryptosat.cpp
@@ -442,10 +442,14 @@ Add iterable of clauses to the solver.\n\
 
 static PyObject* add_clauses(Solver *self, PyObject *args, PyObject *kwds)
 {
-    static char* kwlist[] = {"clauses", NULL};
+    static char* kwlist[] = {"clauses", "max_var", NULL};
     PyObject *clauses;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", kwlist, &clauses)) {
+    long int max_var = 0;
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|l", kwlist, &clauses, &max_var)) {
         return NULL;
+    }
+    if (max_var >= (long int)self->cmsat->nVars()) {
+        self->cmsat->new_vars(max_var-(long int)self->cmsat->nVars()+1);
     }
 
     int add_array_ret = add_clauses_array(self, clauses);

--- a/python/src/pycryptosat.cpp
+++ b/python/src/pycryptosat.cpp
@@ -406,7 +406,7 @@ static int add_clauses_array(Solver *self, PyObject *clauses)
     }
     PyObject *py_array_address = PyTuple_GetItem(buffer_info, 0);
     long array_length = PyLong_AsLong(PyTuple_GetItem(buffer_info, 1));
-    if (array_length < 9) {
+    if (array_length < 0) {
         PyErr_SetString(PyExc_ValueError, "invalid clause array: could not get array length");
         return 0;
     }

--- a/python/src/pycryptosat.cpp
+++ b/python/src/pycryptosat.cpp
@@ -334,6 +334,101 @@ static PyObject* add_clause(Solver *self, PyObject *args, PyObject *kwds)
     return Py_None;
 }
 
+template <typename T>
+static int _add_clauses_array(Solver *self, size_t array_length, const T *array)
+{
+    if (array_length == 0) {
+        return 1;
+    }
+    if (array[array_length - 1] != 0) {
+        PyErr_SetString(PyExc_ValueError, "last clause not terminated by zero");
+        return 0;
+    }
+    size_t k = 0;
+    long val = 0;
+    std::vector<Lit> lits;
+    for (val = (long) array[k]; k < array_length; val = (long) array[++k]) {
+        if (val == 0) {
+            PyErr_SetString(PyExc_ValueError, "non-zero integer expected");
+            return 0;
+        }
+        lits.clear();
+        for (; k < array_length && val != 0; val = (long) array[++k]) {
+            long var;
+            bool sign;
+            if (val > std::numeric_limits<int>::max()/2
+                || val < std::numeric_limits<int>::min()/2
+            ) {
+                PyErr_Format(PyExc_ValueError, "integer %ld is too small or too large", val);
+                return 0;
+            }
+
+            sign = (val < 0);
+            var = std::abs(val) - 1;
+
+            if (var >= self->cmsat->nVars()) {
+                for(long i = (long)self->cmsat->nVars(); i <= var ; i++) {
+                    self->cmsat->new_var();
+                }
+            }
+
+            lits.push_back(Lit(var, sign));
+        }
+        self->cmsat->add_clause(lits);
+    }
+    return 1;
+}
+
+static int add_clauses_array(Solver *self, PyObject *clauses)
+{
+    if (
+        !PyObject_HasAttr(clauses, PyUnicode_FromString("buffer_info")) ||
+        !PyObject_HasAttr(clauses, PyUnicode_FromString("typecode"))
+    ) {
+        return -1;
+    }
+    PyObject *buffer_info = PyObject_CallMethod(clauses, "buffer_info", NULL);
+    PyObject *typecode = PyObject_GetAttrString(clauses, "typecode");
+    if (buffer_info == NULL || typecode == NULL) {
+        PyErr_SetString(PyExc_ValueError, "invalid clause array: buffer_info or typecode is NULL");
+        return 0;
+    }
+    PyObject *typecode_bytes = PyUnicode_AsASCIIString(typecode);
+    if (typecode_bytes == NULL) {
+        PyErr_SetString(PyExc_ValueError, "invalid clause array: typecode string is NULL");
+        return 0;
+    }
+    const char *typecode_cstr = PyBytes_AsString(typecode_bytes);
+    if (typecode_cstr == NULL) {
+        PyErr_SetString(PyExc_ValueError, "invalid clause array: typecode string is NULL");
+        return 0;
+    }
+    PyObject *py_array_address = PyTuple_GetItem(buffer_info, 0);
+    long array_length = PyLong_AsLong(PyTuple_GetItem(buffer_info, 1));
+    if (array_length < 9) {
+        PyErr_SetString(PyExc_ValueError, "invalid clause array: could not get array length");
+        return 0;
+    }
+    if (typecode_cstr[1] != '\0') {
+        PyErr_Format(PyExc_ValueError, "invalid clause array: invalid typecode '%s'", typecode_cstr);
+        return 0;
+    }
+    switch (typecode_cstr[0]) {
+    case 'i':
+        return _add_clauses_array(
+            self, array_length, (const int *) PyLong_AsVoidPtr(py_array_address));
+    case 'l':
+        return _add_clauses_array(
+            self, array_length, (const long *) PyLong_AsVoidPtr(py_array_address));
+    case 'q':
+        return _add_clauses_array(
+            self, array_length, (const long long *) PyLong_AsVoidPtr(py_array_address));
+    default:
+        PyErr_Format(PyExc_ValueError, "invalid clause array: invalid typecode '%s'", typecode_cstr);
+        return 0;
+    }
+}
+
 PyDoc_STRVAR(add_clauses_doc,
 "add_clauses(clauses)\n\
 Add iterable of clauses to the solver.\n\
@@ -350,6 +445,15 @@ static PyObject* add_clauses(Solver *self, PyObject *args, PyObject *kwds)
     PyObject *clauses;
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", kwlist, &clauses)) {
         return NULL;
+    }
+
+    int add_array_ret = add_clauses_array(self, clauses);
+    if (add_array_ret == 0) {
+        return 0;
+    }
+    if (add_array_ret == 1) {
+        Py_INCREF(Py_None);
+        return Py_None;
     }
 
     PyObject *iterator = PyObject_GetIter(clauses);

--- a/src/clausedumper.cpp
+++ b/src/clausedumper.cpp
@@ -169,6 +169,14 @@ void ClauseDumper::dump_irred_cls(std::ostream *out, bool outer_numbering)
         exit(-1);
     }
 
+    size_t num_cls = get_preprocessor_num_cls(outer_numbering);
+    num_cls += dump_blocked_clauses(NULL, outer_numbering);
+    num_cls += dump_component_clauses(NULL, outer_numbering);
+
+    *out
+    << "p cnf " << solver->nVars()
+    << " " << num_cls << "\n";
+
     dump_irred_cls_for_preprocessor(out, outer_numbering);
 
     *out << "c ------------------ previously eliminated variables" << endl;
@@ -195,19 +203,23 @@ void ClauseDumper::dump_unit_cls(std::ostream *out, bool outer_numbering)
     }
 }
 
-void ClauseDumper::dump_blocked_clauses(std::ostream *out, bool outer_numbering) {
+uint32_t ClauseDumper::dump_blocked_clauses(std::ostream *out, bool outer_numbering) {
     assert(outer_numbering);
+    uint32_t num_cls = 0;
     if (solver->conf.perform_occur_based_simp) {
-        solver->occsimplifier->dump_blocked_clauses(out);
+        num_cls = solver->occsimplifier->dump_blocked_clauses(out);
     }
+    return num_cls;
 }
 
-void ClauseDumper::dump_component_clauses(std::ostream *out, bool outer_numbering)
+uint32_t ClauseDumper::dump_component_clauses(std::ostream *out, bool outer_numbering)
 {
     assert(outer_numbering);
+    uint32_t num_cls = 0;
     if (solver->compHandler) {
-        solver->compHandler->dump_removed_clauses(out);
+        num_cls = solver->compHandler->dump_removed_clauses(out);
     }
+    return num_cls;
 }
 
 void ClauseDumper::open_dump_file(const std::string& filename)

--- a/src/clausedumper.cpp
+++ b/src/clausedumper.cpp
@@ -176,8 +176,6 @@ void ClauseDumper::dump_irred_cls(std::ostream *out, bool outer_numbering)
 
     *out << "c ---------- clauses in components" << endl;
     dump_component_clauses(out, outer_numbering);
-
-    dump_vars_appearing_inverted(out, outer_numbering);
 }
 
 void ClauseDumper::dump_unit_cls(std::ostream *out, bool outer_numbering)

--- a/src/clausedumper.h
+++ b/src/clausedumper.h
@@ -74,6 +74,7 @@ private:
         , const bool dumpIrred
         , const bool outer_number
     );
+    size_t get_preprocessor_num_cls(bool outer_numbering);
     void dump_red_cls(std::ostream *out, bool outer_numbering);
     void dump_eq_lits(std::ostream *out, bool outer_numbering);
     void dump_unit_cls(std::ostream *out, bool outer_numbering);

--- a/src/clausedumper.h
+++ b/src/clausedumper.h
@@ -49,6 +49,12 @@ public:
         }
     }
 
+    void write_unsat(std::ostream *out);
+    void write_sat(std::ostream *out);
+    void dump_irred_clauses_preprocessor(std::ostream *out);
+    void dump_irred_clauses(std::ostream *out);
+    void dump_red_clauses(std::ostream *out);
+
     void open_file_and_write_unsat(const std::string& fname);
     void open_file_and_write_sat(const std::string& fname);
     void open_file_and_dump_irred_clauses_preprocessor(const std::string& fname);
@@ -60,23 +66,22 @@ private:
     const Solver* solver;
     std::ofstream* outfile = NULL;
 
-    void write_unsat_file();
-    void dump_irred_cls_for_preprocessor(bool outer_number);
     void open_dump_file(const std::string& filename);
-    void dump_bin_cls(
+
+    void dump_irred_cls_for_preprocessor(std::ostream *out, bool outer_number);
+    void dump_bin_cls(std::ostream *out,
         const bool dumpRed
         , const bool dumpIrred
         , const bool outer_number
     );
-
-    void dump_red_cls(bool outer_numbering);
-    void dump_eq_lits(bool outer_numbering);
-    void dump_unit_cls(bool outer_numbering);
-    void dump_blocked_clauses(bool outer_numbering);
-    void dump_irred_cls(bool outer_numbering);
-    void dump_component_clauses(bool outer_numbering);
-    void dump_vars_appearing_inverted(bool outer_numbering);
-    void dump_clauses(
+    void dump_red_cls(std::ostream *out, bool outer_numbering);
+    void dump_eq_lits(std::ostream *out, bool outer_numbering);
+    void dump_unit_cls(std::ostream *out, bool outer_numbering);
+    void dump_blocked_clauses(std::ostream *out, bool outer_numbering);
+    void dump_irred_cls(std::ostream *out, bool outer_numbering);
+    void dump_component_clauses(std::ostream *out, bool outer_numbering);
+    void dump_vars_appearing_inverted(std::ostream *out, bool outer_numbering);
+    void dump_clauses(std::ostream *out,
         const vector<ClOffset>& cls
         , const bool outer_number
     );

--- a/src/clausedumper.h
+++ b/src/clausedumper.h
@@ -78,9 +78,9 @@ private:
     void dump_red_cls(std::ostream *out, bool outer_numbering);
     void dump_eq_lits(std::ostream *out, bool outer_numbering);
     void dump_unit_cls(std::ostream *out, bool outer_numbering);
-    void dump_blocked_clauses(std::ostream *out, bool outer_numbering);
+    uint32_t dump_blocked_clauses(std::ostream *out, bool outer_numbering);
     void dump_irred_cls(std::ostream *out, bool outer_numbering);
-    void dump_component_clauses(std::ostream *out, bool outer_numbering);
+    uint32_t dump_component_clauses(std::ostream *out, bool outer_numbering);
     void dump_vars_appearing_inverted(std::ostream *out, bool outer_numbering);
     void dump_clauses(std::ostream *out,
         const vector<ClOffset>& cls

--- a/src/comphandler.cpp
+++ b/src/comphandler.cpp
@@ -750,8 +750,12 @@ void CompHandler::readdRemovedClauses()
     removedClauses.sizes.clear();
 }
 
-void CompHandler::dump_removed_clauses(std::ostream* outfile) const
+uint32_t CompHandler::dump_removed_clauses(std::ostream* outfile) const
 {
+    if (outfile == NULL)
+        return removedClauses.sizes.size();
+
+    uint32_t num_cls = 0;
     vector<Lit> tmp;
     size_t at = 0;
     for (uint32_t size :removedClauses.sizes) {
@@ -761,8 +765,10 @@ void CompHandler::dump_removed_clauses(std::ostream* outfile) const
         }
         std::sort(tmp.begin(), tmp.end());
         *outfile << tmp << " 0" << endl;
+        num_cls ++;
 
         //Move 'at' along
         at += size;
     }
+    return num_cls;
 }

--- a/src/comphandler.h
+++ b/src/comphandler.h
@@ -66,7 +66,7 @@ class CompHandler
         void addSavedState(vector<lbool>& solution);
         void readdRemovedClauses();
         const RemovedClauses& getRemovedClauses() const;
-        void dump_removed_clauses(std::ostream* outfile) const;
+        uint32_t dump_removed_clauses(std::ostream* outfile) const;
         size_t get_num_vars_removed() const;
         size_t get_num_components_solved() const;
         size_t mem_used() const;

--- a/src/cryptominisat.cpp
+++ b/src/cryptominisat.cpp
@@ -1072,6 +1072,16 @@ DLL_PUBLIC uint64_t SATSolver::get_last_decisions()
     return get_sum_decisions() - data->previous_sum_decisions;
 }
 
+DLL_PUBLIC void SATSolver::dump_irred_clauses(std::ostream *out) const
+{
+    data->solvers[data->which_solved]->dump_irred_clauses(out);
+}
+
+void DLL_PUBLIC SATSolver::dump_red_clauses(std::ostream *out) const
+{
+    data->solvers[data->which_solved]->dump_red_clauses(out);
+}
+
 DLL_PUBLIC void SATSolver::open_file_and_dump_irred_clauses(std::string fname) const
 {
     data->solvers[data->which_solved]->open_file_and_dump_irred_clauses(fname);

--- a/src/cryptominisat.h.in
+++ b/src/cryptominisat.h.in
@@ -133,6 +133,8 @@ namespace CMSat {
         void print_stats() const; //print solving stats. Call after solve()/simplify()
         void set_drat(std::ostream* os, bool set_ID); //set drat to ostream, e.g. stdout or a file
         void interrupt_asap(); //call this asynchronously, and the solver will try to cleanly abort asap
+        void dump_irred_clauses(std::ostream *out) const; //dump irredundant clauses to this stream when solving finishes
+        void dump_red_clauses(std::ostream *out) const; //dump redundant ("learnt") clauses to this stream when solving finishes
         void open_file_and_dump_irred_clauses(std::string fname) const; //dump irredundant clauses to this file when solving finishes
         void open_file_and_dump_red_clauses(std::string fname) const; //dump redundant ("learnt") clauses to this file when solving finishes
         void add_in_partial_solving_stats(); //used only by Ctrl+C handler. Ignore.

--- a/src/occsimplifier.cpp
+++ b/src/occsimplifier.cpp
@@ -179,8 +179,9 @@ void OccSimplifier::print_blocked_clauses_reverse() const
     }
 }
 
-void OccSimplifier::dump_blocked_clauses(std::ostream* outfile) const
+uint32_t OccSimplifier::dump_blocked_clauses(std::ostream* outfile) const
 {
+    uint32_t num_cls = 0;
     for (BlockedClauses blocked: blockedClauses) {
         if (blocked.toRemove)
             continue;
@@ -191,16 +192,20 @@ void OccSimplifier::dump_blocked_clauses(std::ostream* outfile) const
                 continue;
             }
             Lit l = blocked.at(i, blkcls);
-            if (l == lit_Undef) {
-                *outfile
-                << " 0"
-                << endl;
-            } else {
-                *outfile
-                << l << " ";
+            if (outfile != NULL) {
+                if (l == lit_Undef) {
+                    *outfile
+                    << " 0"
+                    << endl;
+                } else {
+                    *outfile
+                    << l << " ";
+                }
             }
+            num_cls++;
         }
     }
+    return num_cls;
 }
 
 void OccSimplifier::extend_model(SolutionExtender* extender)

--- a/src/occsimplifier.h
+++ b/src/occsimplifier.h
@@ -224,7 +224,7 @@ public:
     size_t mem_used_xor() const;
     size_t mem_used_bva() const;
     void print_gatefinder_stats() const;
-    void dump_blocked_clauses(std::ostream* outfile) const;
+    uint32_t dump_blocked_clauses(std::ostream* outfile) const;
 
     //UnElimination
     void print_blocked_clauses_reverse() const;

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -637,12 +637,6 @@ bool Solver::addClauseHelper(vector<Lit>& ps)
 
 bool Solver::addClause(const vector<Lit>& lits, bool red)
 {
-    vector<Lit> ps = lits;
-    return addClauseInt(ps, red);
-}
-
-bool Solver::addClauseInt(vector<Lit>& ps, bool red)
-{
     if (conf.perform_occur_based_simp && occsimplifier->getAnythingHasBeenBlocked()) {
         std::cerr
         << "ERROR: Cannot add new clauses to the system if blocking was"
@@ -652,9 +646,11 @@ bool Solver::addClauseInt(vector<Lit>& ps, bool red)
     }
 
     #ifdef VERBOSE_DEBUG
-    cout << "Adding clause " << ps << endl;
+    cout << "Adding clause " << lits << endl;
     #endif //VERBOSE_DEBUG
     const size_t origTrailSize = trail.size();
+
+    vector<Lit> ps = lits;
 
     if (!addClauseHelper(ps)) {
         return false;
@@ -2957,7 +2953,7 @@ bool Solver::add_clause_outer(const vector<Lit>& lits, bool red)
     }
     check_too_large_variable_number(lits);
     back_number_from_outside_to_outer(lits);
-    return addClauseInt(back_number_from_outside_to_outer_tmp, red);
+    return addClause(back_number_from_outside_to_outer_tmp, red);
 }
 
 bool Solver::add_xor_clause_outer(const vector<uint32_t>& vars, bool rhs)

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -2953,7 +2953,9 @@ bool Solver::add_clause_outer(const vector<Lit>& lits, bool red)
     if (!ok) {
         return false;
     }
+    #ifdef SLOW_DEBUG //we check for this during back-numbering
     check_too_large_variable_number(lits);
+    #endif
     back_number_from_outside_to_outer(lits);
     return addClause(back_number_from_outside_to_outer_tmp, red);
 }
@@ -2968,7 +2970,9 @@ bool Solver::add_xor_clause_outer(const vector<uint32_t>& vars, bool rhs)
     for(size_t i = 0; i < vars.size(); i++) {
         lits[i] = Lit(vars[i], false);
     }
+    #ifdef SLOW_DEBUG //we check for this during back-numbering
     check_too_large_variable_number(lits);
+    #endif
 
     back_number_from_outside_to_outer(lits);
     addClauseHelper(back_number_from_outside_to_outer_tmp);

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -320,7 +320,7 @@ bool Solver::sort_and_clean_clause(
         } else if (value(ps[i]) != l_False && ps[i] != p) {
             ps[j++] = p = ps[i];
 
-            if (varData[p.var()].removed != Removed::none) {
+            if (!fresh_solver && varData[p.var()].removed != Removed::none) {
                 cout << "ERROR: clause " << origCl << " contains literal "
                 << p << " whose variable has been removed (removal type: "
                 << removed_type_to_string(varData[p.var()].removed)
@@ -328,11 +328,11 @@ bool Solver::sort_and_clean_clause(
                 << varReplacer->get_var_replaced_with(p)
                 << ")"
                 << endl;
-            }
 
-            //Variables that have been eliminated cannot be added internally
-            //as part of a clause. That's a bug
-            assert(varData[p.var()].removed == Removed::none);
+                //Variables that have been eliminated cannot be added internally
+                //as part of a clause. That's a bug
+                assert(varData[p.var()].removed == Removed::none);
+            }
         }
     }
     ps.resize(ps.size() - (i - j));

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -651,7 +651,8 @@ bool Solver::addClause(const vector<Lit>& lits, bool red)
     #endif //VERBOSE_DEBUG
     const size_t origTrailSize = trail.size();
 
-    vector<Lit> ps = lits;
+    add_clause_int_tmp_cl = lits;
+    vector<Lit>& ps = add_clause_int_tmp_cl;
 
     if (!addClauseHelper(ps)) {
         return false;

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -369,7 +369,8 @@ Clause* Solver::add_clause_int(
         std::min<uint64_t>(Searcher::sumConflicts, cl_stats.introduced_at_conflict);
     #endif
 
-    vector<Lit> ps = lits;
+    add_clause_int_tmp_cl = lits;
+    vector<Lit>& ps = add_clause_int_tmp_cl;
     if (!sort_and_clean_clause(ps, lits, red)) {
         if (finalLits) {
             finalLits->clear();

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -3868,14 +3868,25 @@ vector<Lit> Solver::get_toplevel_units_internal(bool outer_numbering) const
     return units;
 }
 
+void Solver::dump_irred_clauses(std::ostream *out) const
+{
+    ClauseDumper dumper(this);
+    dumper.dump_irred_clauses(out);
+}
 
-void Solver::open_file_and_dump_irred_clauses(string fname) const
+void Solver::dump_red_clauses(std::ostream *out) const
+{
+    ClauseDumper dumper(this);
+    dumper.dump_red_clauses(out);
+}
+
+void Solver::open_file_and_dump_irred_clauses(const std::string &fname) const
 {
     ClauseDumper dumper(this);
     dumper.open_file_and_dump_irred_clauses(fname);
 }
 
-void Solver::open_file_and_dump_red_clauses(string fname) const
+void Solver::open_file_and_dump_red_clauses(const std::string &fname) const
 {
     ClauseDumper dumper(this);
     dumper.open_file_and_dump_red_clauses(fname);

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -637,6 +637,12 @@ bool Solver::addClauseHelper(vector<Lit>& ps)
 
 bool Solver::addClause(const vector<Lit>& lits, bool red)
 {
+    vector<Lit> ps = lits;
+    return addClauseInt(ps, red);
+}
+
+bool Solver::addClauseInt(vector<Lit>& ps, bool red)
+{
     if (conf.perform_occur_based_simp && occsimplifier->getAnythingHasBeenBlocked()) {
         std::cerr
         << "ERROR: Cannot add new clauses to the system if blocking was"
@@ -646,11 +652,9 @@ bool Solver::addClause(const vector<Lit>& lits, bool red)
     }
 
     #ifdef VERBOSE_DEBUG
-    cout << "Adding clause " << lits << endl;
+    cout << "Adding clause " << ps << endl;
     #endif //VERBOSE_DEBUG
     const size_t origTrailSize = trail.size();
-
-    vector<Lit> ps = lits;
 
     if (!addClauseHelper(ps)) {
         return false;
@@ -2953,7 +2957,7 @@ bool Solver::add_clause_outer(const vector<Lit>& lits, bool red)
     }
     check_too_large_variable_number(lits);
     back_number_from_outside_to_outer(lits);
-    return addClause(back_number_from_outside_to_outer_tmp, red);
+    return addClauseInt(back_number_from_outside_to_outer_tmp, red);
 }
 
 bool Solver::add_xor_clause_outer(const vector<uint32_t>& vars, bool rhs)

--- a/src/solver.h
+++ b/src/solver.h
@@ -376,7 +376,6 @@ class Solver : public Searcher
         /////////////////////
         // Clauses
         bool addClauseHelper(vector<Lit>& ps);
-        bool addClauseInt(vector<Lit>& ps, const bool red = false);
 
         /////////////////
         // Debug

--- a/src/solver.h
+++ b/src/solver.h
@@ -260,6 +260,7 @@ class Solver : public Searcher
         FRIEND_TEST(SearcherTest, pickpolar_auto_not_changed_by_simp);
         #endif
 
+        vector<Lit> add_clause_int_tmp_cl;
         lbool iterate_until_solved();
         uint64_t mem_used_vardata() const;
         void check_reconfigure();

--- a/src/solver.h
+++ b/src/solver.h
@@ -106,8 +106,10 @@ class Solver : public Searcher
         bool get_next_small_clause(std::vector<Lit>& out);
         void end_getting_small_clauses();
 
-        void open_file_and_dump_irred_clauses(string fname) const;
-        void open_file_and_dump_red_clauses(string fname) const;
+        void dump_irred_clauses(std::ostream *out) const;
+        void dump_red_clauses(std::ostream *out) const;
+        void open_file_and_dump_irred_clauses(const std::string &fname) const;
+        void open_file_and_dump_red_clauses(const std::string &fname) const;
 
         static const char* get_version_tag();
         static const char* get_version_sha1();

--- a/src/solver.h
+++ b/src/solver.h
@@ -376,6 +376,7 @@ class Solver : public Searcher
         /////////////////////
         // Clauses
         bool addClauseHelper(vector<Lit>& ps);
+        bool addClauseInt(vector<Lit>& ps, const bool red = false);
 
         /////////////////
         // Debug

--- a/src/solver.h
+++ b/src/solver.h
@@ -296,8 +296,12 @@ class Solver : public Searcher
             back_number_from_outside_to_outer_tmp.clear();
             for (const Lit lit: lits) {
                 assert(lit.var() < nVarsOutside());
-                back_number_from_outside_to_outer_tmp.push_back(map_to_with_bva(lit));
-                assert(back_number_from_outside_to_outer_tmp.back().var() < nVarsOuter());
+                if (!fresh_solver) {
+                    back_number_from_outside_to_outer_tmp.push_back(map_to_with_bva(lit));
+                    assert(back_number_from_outside_to_outer_tmp.back().var() < nVarsOuter());
+                } else {
+                    back_number_from_outside_to_outer_tmp.push_back(lit);
+                }
             }
         }
         void check_switchoff_limits_newvar(size_t n = 1);

--- a/src/solver.h
+++ b/src/solver.h
@@ -188,7 +188,11 @@ class Solver : public Searcher
         //Attaching-detaching clauses
         void attachClause(
             const Clause& c
+            #ifdef DEBUG_ATTACH
             , const bool checkAttach = true
+            #else
+            , const bool checkAttach = false
+            #endif
         );
         void attach_bin_clause(
             const Lit lit1


### PR DESCRIPTION
\[ DISCLAIMER: This is no production-ready code, just for testing and unfinished, plus I know next to nothing about how to efficiently work with Python C-API :wink: \]

This is in reference to
- https://github.com/msoos/cryptominisat/issues/513, and
- https://github.com/conda/conda/pull/7676

I put together some non-polished interface to be able to pass clauses to `Solver.add_clauses` as a Python `array.array("i")` object. This is so we can compare the time taken on processing the clauses as a simple stream of integers (separated by zeros) to processing them as iterables of iterables, e.g., list of tuples, which the current interface expects.
Since the time taken to scan an integer array is practically zero (if we need to see all values anyways, that is), the remaining time of adding clauses can be assumed to be spent outside of the Python interface, i.e., be admeasured to the core library.

I'll follow up with some measurement results..