### PR TITLE
python: add_clauses: add max_var=0 kwarg

### DIFF
--- a/python/src/pycryptosat.cpp
+++ b/python/src/pycryptosat.cpp
@@ -348,10 +348,14 @@ Add iterable of clauses to the solver.\n\
 
 static PyObject* add_clauses(Solver *self, PyObject *args, PyObject *kwds)
 {
-    static char* kwlist[] = {"clauses", NULL};
+    static char* kwlist[] = {"clauses", "max_var", NULL};
     PyObject *clauses;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", kwlist, &clauses)) {
+    long int max_var = 0;
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|l", kwlist, &clauses, &max_var)) {
         return NULL;
+    }
+    if (max_var >= (long int)self->cmsat->nVars()) {
+        self->cmsat->new_vars(max_var-(long int)self->cmsat->nVars()+1);
     }
 
     PyObject *iterator = PyObject_GetIter(clauses);

--- a/python/src/pycryptosat.cpp
+++ b/python/src/pycryptosat.cpp
@@ -354,8 +354,8 @@ static PyObject* add_clauses(Solver *self, PyObject *args, PyObject *kwds)
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|l", kwlist, &clauses, &max_var)) {
         return NULL;
     }
-    if (max_var >= (long int)self->cmsat->nVars()) {
-        self->cmsat->new_vars(max_var-(long int)self->cmsat->nVars()+1);
+    if (max_var > (long int)self->cmsat->nVars()) {
+        self->cmsat->new_vars(max_var-(long int)self->cmsat->nVars());
     }
 
     PyObject *iterator = PyObject_GetIter(clauses);

--- a/scripts/performance/addclause.py
+++ b/scripts/performance/addclause.py
@@ -31,7 +31,7 @@ import pycosat
 
 def cms_setup(clauses, m):
     solver = pycryptosat.Solver()
-    solver.add_clauses(clauses)
+    solver.add_clauses(clauses, max_var=m)
     return solver
 
 


### PR DESCRIPTION
Adds `max_var=0` keyword argument to `add_clauses` in the Python interface.
This lets one specify the maximum variable number that is used in the given clauses and in turn enables speedups in case a high number of new variables is added.
xrefs: https://github.com/msoos/cryptominisat/pull/515#issuecomment-415856002, https://github.com/msoos/cryptominisat/pull/515#issuecomment-415901769