### PR TITLE
Solver::addClause: use add_clause_int_tmp_cl

### DIFF
--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -638,6 +638,12 @@ bool Solver::addClauseHelper(vector<Lit>& ps)
 
 bool Solver::addClause(const vector<Lit>& lits, bool red)
 {
+    vector<Lit> ps = lits;
+    return Solver::addClauseInt(ps, red);
+}
+
+bool Solver::addClauseInt(vector<Lit>& ps, bool red)
+{
     if (conf.perform_occur_based_simp && occsimplifier->getAnythingHasBeenBlocked()) {
         std::cerr
         << "ERROR: Cannot add new clauses to the system if blocking was"
@@ -647,12 +653,9 @@ bool Solver::addClause(const vector<Lit>& lits, bool red)
     }
 
     #ifdef VERBOSE_DEBUG
-    cout << "Adding clause " << lits << endl;
+    cout << "Adding clause " << ps << endl;
     #endif //VERBOSE_DEBUG
     const size_t origTrailSize = trail.size();
-
-    addClause_tmp_cl = lits;
-    vector<Lit>& ps = addClause_tmp_cl;
 
     if (!addClauseHelper(ps)) {
         return false;
@@ -2957,7 +2960,7 @@ bool Solver::add_clause_outer(const vector<Lit>& lits, bool red)
     check_too_large_variable_number(lits);
     #endif
     back_number_from_outside_to_outer(lits);
-    return addClause(back_number_from_outside_to_outer_tmp, red);
+    return addClauseInt(back_number_from_outside_to_outer_tmp, red);
 }
 
 bool Solver::add_xor_clause_outer(const vector<uint32_t>& vars, bool rhs)

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -651,7 +651,8 @@ bool Solver::addClause(const vector<Lit>& lits, bool red)
     #endif //VERBOSE_DEBUG
     const size_t origTrailSize = trail.size();
 
-    vector<Lit> ps = lits;
+    add_clause_int_tmp_cl = lits;
+    vector<Lit>& ps = add_clause_int_tmp_cl;
 
     if (!addClauseHelper(ps)) {
         return false;

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -651,8 +651,8 @@ bool Solver::addClause(const vector<Lit>& lits, bool red)
     #endif //VERBOSE_DEBUG
     const size_t origTrailSize = trail.size();
 
-    add_clause_int_tmp_cl = lits;
-    vector<Lit>& ps = add_clause_int_tmp_cl;
+    addClause_tmp_cl = lits;
+    vector<Lit>& ps = addClause_tmp_cl;
 
     if (!addClauseHelper(ps)) {
         return false;

--- a/src/solver.h
+++ b/src/solver.h
@@ -267,6 +267,7 @@ class Solver : public Searcher
         #endif
 
         vector<Lit> add_clause_int_tmp_cl;
+        vector<Lit> addClause_tmp_cl;
         lbool iterate_until_solved();
         uint64_t mem_used_vardata() const;
         void check_reconfigure();

--- a/src/solver.h
+++ b/src/solver.h
@@ -267,7 +267,6 @@ class Solver : public Searcher
         #endif
 
         vector<Lit> add_clause_int_tmp_cl;
-        vector<Lit> addClause_tmp_cl;
         lbool iterate_until_solved();
         uint64_t mem_used_vardata() const;
         void check_reconfigure();
@@ -388,6 +387,7 @@ class Solver : public Searcher
         /////////////////////
         // Clauses
         bool addClauseHelper(vector<Lit>& ps);
+        bool addClauseInt(vector<Lit>& ps, const bool red = false);
 
         /////////////////
         // Debug


### PR DESCRIPTION
This is a follow-up to https://github.com/msoos/cryptominisat/pull/515#issuecomment-415870385 ff. and https://github.com/msoos/cryptominisat/commit/3baaafe678057a043f93569505da72071ea79a52.

We can avoid copying the input clause not only in `add_clause_int` but also in `addClause`, which gives another speed up.