### PR TITLE
python: add_clauses: support array.array as input

### DIFF
--- a/scripts/performance/addclause.py
+++ b/scripts/performance/addclause.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
             continue
 
         my_type_list = ("list", clause_list), ("array", clause_array)
-        my_type_list = ("list", clause_list), (None, None)
+        #my_type_list = ("list", clause_list), (None, None)
         for clauses_type, clauses in (my_type_list):
             if clauses is None:
                 continue


### PR DESCRIPTION
Adds support to the `add_clauses` method of the Python interface for passing over clauses as a flat `array.array` of integers. Each clause has to be terminated by a zero, such that the integer array represents a stream of zero separated clauses.

In a subsequent step, this could be improved upon to support not only `array.array` instances but additionally support the [Python C-API buffer protocol](https://docs.python.org/3/c-api/buffer.html). If anyone with more experience around the Python C-API wants to volunteer for it, this would be highly appreciated!