### PR TITLE
Add clauses speedups

### DIFF
--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -300,8 +300,11 @@ bool Solver::sort_and_clean_clause(
     vector<Lit>& ps
     , const vector<Lit>& origCl
     , const bool red
+    , const bool sorted
 ) {
-    std::sort(ps.begin(), ps.end());
+    if (!sorted) {
+        std::sort(ps.begin(), ps.end());
+    }
     Lit p = lit_Undef;
     uint32_t i, j;
     for (i = j = 0; i != ps.size(); i++) {
@@ -355,6 +358,7 @@ Clause* Solver::add_clause_int(
     , vector<Lit>* finalLits
     , bool addDrat
     , const Lit drat_first
+    , const bool sorted
 ) {
     assert(ok);
     assert(decisionLevel() == 0);
@@ -371,7 +375,7 @@ Clause* Solver::add_clause_int(
 
     add_clause_int_tmp_cl = lits;
     vector<Lit>& ps = add_clause_int_tmp_cl;
-    if (!sort_and_clean_clause(ps, lits, red)) {
+    if (!sort_and_clean_clause(ps, lits, red, sorted)) {
         if (finalLits) {
             finalLits->clear();
         }
@@ -675,6 +679,8 @@ bool Solver::addClauseInt(vector<Lit>& ps, bool red)
         , true //yes, attach
         , pFinalCl
         , false //add drat?
+        , lit_Undef
+        , true
     );
 
     //Drat -- We manipulated the clause, delete

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -661,14 +661,19 @@ bool Solver::addClauseInt(vector<Lit>& ps, bool red)
         return false;
     }
 
-    finalCl_tmp.clear();
     std::sort(ps.begin(), ps.end());
-    Clause* cl = add_clause_int(
+
+    vector<Lit> *pFinalCl = NULL;
+    if (drat->enabled() || conf.simulate_drat) {
+        finalCl_tmp.clear();
+        pFinalCl = &finalCl_tmp;
+    }
+    Clause *cl = add_clause_int(
         ps
         , red
         , ClauseStats() //default stats
         , true //yes, attach
-        , &finalCl_tmp
+        , pFinalCl
         , false //add drat?
     );
 

--- a/src/solver.h
+++ b/src/solver.h
@@ -231,6 +231,7 @@ class Solver : public Searcher
             , vector<Lit>* finalLits = NULL
             , bool addDrat = true
             , const Lit drat_first = lit_Undef
+            , const bool sorted = false
         );
         template<class T> vector<Lit> clause_outer_numbered(const T& cl) const;
         template<class T> vector<uint32_t> xor_outer_numbered(const T& cl) const;
@@ -275,7 +276,12 @@ class Solver : public Searcher
         long calc_num_confl_to_do_this_iter(const size_t iteration_num) const;
 
         vector<Lit> finalCl_tmp;
-        bool sort_and_clean_clause(vector<Lit>& ps, const vector<Lit>& origCl, const bool red);
+        bool sort_and_clean_clause(
+            vector<Lit>& ps
+            , const vector<Lit>& origCl
+            , const bool red
+            , const bool sorted = false
+        );
         void set_up_sql_writer();
         vector<std::pair<string, string> > sql_tags;
 


### PR DESCRIPTION
I've just been too curious whether a profiler would show some more obvious places where performance tweaks can be applied ^^.
Here are two additional small uncontroversial improvements for `add_clauses` and probably the last contributions from my side in regards to speeding that up. With that we have:
`master` at https://github.com/msoos/cryptominisat/commit/e4803df9d14ea74c820a91b988b4d1dac0ad9dd1
```
$ ./scripts/performance/addclause.py
setup CMS     array 0.248 0.249 0.249 0.250 0.257
setup CMS     list  0.419 0.425 0.433 0.441 0.444
setup Pycosat array 0.182 0.183 0.185 0.187 0.187
setup Pycosat list  0.250 0.252 0.252 0.257 0.261
solve CMS     array 0.097 0.097 0.097 0.097 0.098
solve CMS     list  0.098 0.106 0.108 0.108 0.110
solve Pycosat array 1.597 1.604 1.606 1.608 1.613
solve Pycosat list  1.590 1.594 1.601 1.614 1.640
```
`add_clauses-speedups` at https://github.com/msoos/cryptominisat/commit/2a4fb3481f5e99f2c98670e3d6c91e34ec99ba3c
```
$ ./scripts/performance/addclause.py
setup CMS     array 0.230 0.231 0.231 0.233 0.238
setup CMS     list  0.391 0.403 0.405 0.422 0.428
setup Pycosat array 0.179 0.181 0.183 0.184 0.187
setup Pycosat list  0.248 0.252 0.253 0.254 0.255
solve CMS     array 0.096 0.097 0.098 0.098 0.101
solve CMS     list  0.097 0.105 0.107 0.109 0.109
solve Pycosat array 1.585 1.594 1.600 1.601 1.636
solve Pycosat list  1.583 1.589 1.597 1.599 1.631
```

----


Another slight tweak would be to avoid copying the clause in `add_clauses_int` into `add_clause_int_tmp_cl` if we know we can overwrite the input (i.e., make the `lits` argument non-`const`). We can only avoid that copy if `fresh_solver` is true because otherwise the original unmodified `lits` might be used in `sort_and_clean_clause` for an error message. But this would only reduce the time by `2-3 %` or so and at the same time make the code less clear, so that I don't think it's really worth it.

According to Valgrind's output, a good chunk of the remaining time is just used for allocating and initializing memory.
Most of the *allocation* time should come from calls to `CMSat::vec<CMSat::Watched>::capacity` stemming from `PropEngine::attach_bin_clause`. Maybe this part is not so easy to tweak, but I don't really know.
Redundant time used to *initialize* memory is spent in `CNF::new_vars` by running `arr.insert(arr.end(), n, 0);` for `interToOuterMain`, `outerToInterMain`, and `outer_to_with_bva_map`. If the newly allocated memory is completely filled (and not read from) in the following loop in `CNF::new_vars` (which I assume it is, but didn't check), then initializing that memory with zeros is not needed. Well, but since `std::vector<uint32_t>` (= `std::vector<uint32_t, std::allocator<uint32_t>>` ) is used, any `insert` or `resize` call will always initialize/zero out that memory. So to circumvent that, you'd have to use a custom vector or allocator class. Changing that is likely tedious since quite a few places in the code have the type of these vectors hardcoded to `std::vector<uint32_t>`..