### PR TITLE
Add use max_var in add_clauses(...) test case

### DIFF
--- a/python/tests/test_pycryptosat.py
+++ b/python/tests/test_pycryptosat.py
@@ -204,9 +204,10 @@ class TestSolve(unittest.TestCase):
         self.assertTrue(check_solution(clauses1, solution))
 
     def test_add_clauses(self):
-        self.solver.add_clauses([[1], [-1]])
+        self.solver.add_clauses(clauses=[[1], [-1]], max_var=100)
         res, solution = self.solver.solve()
         self.assertEqual(res, False)
+        self.assertEqual(self.solver.nb_vars(), 100)
 
     def test_add_clauses_wrong_zero(self):
         self.assertRaises(TypeError, self.solver.add_clause, [[1, 0], [-1]])


### PR DESCRIPTION
The version of `pycryptosat` packaged by Fedora 29 currently is 5.6.4, which predates some of the recent improvements to the Python API. Not sure if you want it, but this ensures we at least attempt to test `max_vars` as part of the existing test suite. 

(`add_clauses` is called in other places without kwargs, so coverage should only improve... slightly :).

`Signed-off-by: Alexander Scheel <alexander.m.scheel@gmail.com>`