### PR TITLE
Expose get_conflict in pycryptosat

### DIFF
--- a/python/src/pycryptosat.cpp.in
+++ b/python/src/pycryptosat.cpp.in
@@ -991,6 +991,40 @@ static PyObject* msolve_selected(Solver *self, PyObject *args, PyObject *kwds)
     return solutions;
 }
 
+PyDoc_STRVAR(get_conflict_doc,
+"get_conflict()\n\
+Returns the conflicts in the assumptions when the last call to solve(...)\n\
+was unsatisfiable.\n\
+\n\
+:return: Which assumptions (as passed to solve(...)) are incorrect\n\
+:rtype: <list <int>>"
+);
+
+static PyObject* get_conflict(Solver *self)
+{
+    const std::vector<Lit> conflicts = self->cmsat->get_conflict();
+    PyObject *result = PyList_New(0);
+
+    for (unsigned long i = 0; i < conflicts.size(); i++) {
+        Lit lit = conflicts[i];
+        long value = lit.var() + 1;
+
+        if (lit.sign()) {
+            value *= -1;
+        }
+
+        #ifdef IS_PY3K
+        PyObject *item = PyLong_FromLong(value);
+        #else
+        PyObject *item = PyInt_FromLong(value);
+        #endif
+
+        PyList_Append(result, item);
+    }
+
+    return result;
+}
+
 /*************************** Method definitions *************************/
 
 static PyMethodDef module_methods[] = {
@@ -1006,6 +1040,7 @@ static PyMethodDef Solver_methods[] = {
     //{"nb_clauses", (PyCFunction) nb_clauses, METH_VARARGS | METH_KEYWORDS, "returns number of clauses"},
     {"msolve_selected", (PyCFunction) msolve_selected, METH_VARARGS | METH_KEYWORDS, msolve_selected_doc},
     {"is_satisfiable", (PyCFunction) is_satisfiable, METH_VARARGS | METH_KEYWORDS, is_satisfiable_doc},
+    {"get_conflict", (PyCFunction) get_conflict, METH_VARARGS | METH_KEYWORDS, get_conflict_doc},
 
     {"start_getting_small_clauses", (PyCFunction) start_getting_small_clauses, METH_VARARGS | METH_KEYWORDS, start_getting_small_clauses_doc},
     {"get_next_small_clause", (PyCFunction) get_next_small_clause, METH_VARARGS | METH_KEYWORDS, get_next_small_clause_doc},

--- a/python/tests/test_pycryptosat.py
+++ b/python/tests/test_pycryptosat.py
@@ -234,6 +234,33 @@ class TestSolve(unittest.TestCase):
                 return None
         self.assertRaises(TypeError, self.solver.add_clause, Liar())
 
+    def test_get_conflict(self):
+        self.solver.add_clauses([[-1], [2], [3], [-4]])
+        assume = [-2, 3, 4]
+
+        res, model = self.solver.solve(assumptions=assume)
+        self.assertEqual(res, False)
+
+        confl = self.solver.get_conflict()
+        self.assertEqual(isinstance(confl, list), True)
+        self.assertNotIn(3, confl)
+
+        if 2 in confl:
+            self.assertIn(2, confl)
+        elif -4 in confl:
+            self.assertIn(-4, confl)
+        else:
+            self.assertEqual(False, True, msg="Either -2 or 4 should be conflicting!")
+
+        assume = [2, 4]
+        res, model = self.solver.solve(assumptions=assume)
+        self.assertEqual(res, False)
+
+        confl = self.solver.get_conflict()
+        self.assertEqual(isinstance(confl, list), True)
+        self.assertNotIn(2, confl)
+        self.assertIn(-4, confl)
+
     def test_cnf2(self):
         for cl in clauses2:
             self.solver.add_clause(cl)


### PR DESCRIPTION
This lets the user query SATSolver::get_conflict() from pycryptosat,
exposing the result as a dict of bools, representing the variable and
the incorrect value.

`Signed-off-by: Alexander Scheel <alexander.m.scheel@gmail.com>`