### PR TITLE
Avoid implicit conversion from signed to unsigned changing value

### DIFF
--- a/src/Vec.h
+++ b/src/Vec.h
@@ -245,7 +245,7 @@ void vec<T>::capacity(int32_t min_cap)
     }
 
     // NOTE: grow by approximately 3/2
-    uint32_t add = imax((min_cap - cap + 1) & ~1, ((cap >> 1) + 2) & ~1);
+    uint32_t add = imax((min_cap - cap + 1) & ~1u, ((cap >> 1) + 2) & ~1u);
     if (add > std::numeric_limits<uint32_t>::max() - cap
         || (((data = (T*)::realloc(data, (cap += (uint32_t)add) * sizeof(T))) == NULL)
             && errno == ENOMEM)


### PR DESCRIPTION
This does not change the behavior but appeases UBSan:
```sh
$ cmake -DCMAKE_BUILD_TYPE=Debug -DSANITIZE=ON -DCMAKE_CXX_COMPILER=clang++
$ echo 'p cnf 1 0' | cryptominisat5_simple

cryptominisat/src/Vec.h:254:24: runtime error: implicit conversion from type
'int' of value -2 (32-bit, signed) to type 'unsigned int' changed the value
to 4294967294 (32-bit, unsigned)
```