### PR TITLE
Modify the maxTime value to be based off cpuTime (process time) rather than 'solver time', to correctly match the subsequent uses later on

### DIFF
--- a/src/cryptominisat.cpp
+++ b/src/cryptominisat.cpp
@@ -1,5 +1,6 @@
 /******************************************
 Copyright (c) 2016, Mate Soos
+              2019, Andrew V. Jones
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -497,7 +498,10 @@ DLL_PUBLIC void SATSolver::set_max_time(double max_time)
   for (size_t i = 0; i < data->solvers.size(); ++i) {
     Solver& s = *data->solvers[i];
     if (max_time >= 0) {
-      s.conf.maxTime = s.get_stats().cpu_time + max_time;
+      // the main loop in solver.cpp is checks `maxTime`
+      // against `cpuTime`, so we specify `s.conf.maxTime`
+      // as an offset from `cpuTime`.
+      s.conf.maxTime = cpuTime() + max_time;
 
       //don't allow for overflow
       if (s.conf.maxTime < max_time)


### PR DESCRIPTION
In the core of CMS (e.g., `Solver::iterate_until_solved`), the value `conf.maxTime` is checked against `cpuTime`, rather than `s.get_stats().cpu_time`.

This PR modifies the setting of `conf.maxTime` to calculate an offset from `cpuTime` to correctly match its later uses.