### PR TITLE
Saving glue of unminimised clause in SQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ tests/cnf-files/*.sqlite
 scripts/fuzz/fuzzTest_*
 scripts/fuzz/tmp_for_xor_to_cnf_*
 scripts/reconf/outfile*
-
+.vscode
 web/jquery-1.11.3.min.js
 *.pdf
 *.aux

--- a/cmsat_tablestructure.sql
+++ b/cmsat_tablestructure.sql
@@ -150,6 +150,7 @@ CREATE TABLE `clauseStats` (
   `clauseID` bigint(20) NOT NULL,
 
   `glue` int(20) NOT NULL,
+  `old_glue` int(20) NOT NULL,
   `size` int(20) NOT NULL,
   `conflicts_this_restart` bigint(20) NOT NULL,
   `num_overlap_literals` int(20) NOT NULL,

--- a/src/prober.cpp
+++ b/src/prober.cpp
@@ -757,7 +757,7 @@ bool Prober::propagate(Lit& failed)
         PropBy confl = solver->propagate<true>();
         if (!confl.isNULL()) {
             uint32_t  glue;
-            uint32_t  old_glue; //Arijit : Not sure whether this is true either
+            uint32_t  old_glue; 
             uint32_t  backtrack_level;
             solver->analyze_conflict<true>(
                 confl

--- a/src/prober.cpp
+++ b/src/prober.cpp
@@ -757,11 +757,13 @@ bool Prober::propagate(Lit& failed)
         PropBy confl = solver->propagate<true>();
         if (!confl.isNULL()) {
             uint32_t  glue;
+            uint32_t  old_glue; //Arijit : Not sure whether this is true either
             uint32_t  backtrack_level;
             solver->analyze_conflict<true>(
                 confl
                 , backtrack_level  //return backtrack level here
                 , glue             //return glue here
+                , old_glue             //return unminimised glue here
             );
             if (solver->learnt_clause.empty()) {
                 solver->ok = false;

--- a/src/searcher.h
+++ b/src/searcher.h
@@ -285,6 +285,7 @@ class Searcher : public HyperEngine
         Clause* handle_last_confl_otf_subsumption(
             Clause* cl
             , const uint32_t glue
+            , const uint32_t old_glue
             , const uint32_t old_decision_level
         );
         template<bool update_bogoprops>
@@ -320,6 +321,7 @@ class Searcher : public HyperEngine
             PropBy confl //The conflict that we are investigating
             , uint32_t& out_btlevel      //backtrack level
             , uint32_t &glue         //glue of the learnt clause
+            , uint32_t &old_glue         //glue of the unminimised learnt clause
         );
         void update_clause_glue_from_analysis(Clause* cl);
         template<bool update_bogoprops>
@@ -449,6 +451,7 @@ class Searcher : public HyperEngine
         SearchStats lastSQLGlobalStats;
         void dump_sql_clause_data(
             const uint32_t glue
+            , const uint32_t old_glue
             , const uint32_t old_decision_level
             , const uint64_t clid
         );

--- a/src/sqlitestats.cpp
+++ b/src/sqlitestats.cpp
@@ -982,7 +982,7 @@ void SQLiteStats::reduceDB(
 
 void SQLiteStats::init_clause_stats_STMT()
 {
-    const size_t numElems = 66;
+    const size_t numElems = 67;
 
     std::stringstream ss;
     ss << "insert into `clauseStats`"
@@ -995,6 +995,7 @@ void SQLiteStats::init_clause_stats_STMT()
     << " `clauseID`,"
     << ""
     << " `glue`,"
+    << " `old_glue`,"
     << " `size`,"
     << " `conflicts_this_restart`,"
     << " `num_overlap_literals`,"
@@ -1089,6 +1090,7 @@ void SQLiteStats::dump_clause_stats(
     const Solver* solver
     , uint64_t clid
     , uint32_t glue
+    , uint32_t old_glue
     , uint32_t backtrack_level
     , uint32_t size
     , AtecedentData<uint16_t> antec_data
@@ -1117,6 +1119,7 @@ void SQLiteStats::dump_clause_stats(
     sqlite3_bind_int64(stmt_clause_stats, bindAt++, clid);
 
     sqlite3_bind_int(stmt_clause_stats, bindAt++, glue);
+    sqlite3_bind_int(stmt_clause_stats, bindAt++, old_glue);
     sqlite3_bind_int(stmt_clause_stats, bindAt++, size);
     sqlite3_bind_int64(stmt_clause_stats, bindAt++, conflicts_this_restart);
     sqlite3_bind_int(stmt_clause_stats, bindAt++, num_overlap_literals);

--- a/src/sqlitestats.h
+++ b/src/sqlitestats.h
@@ -88,6 +88,7 @@ public:
         const Solver* solver
         , uint64_t clid
         , uint32_t glue
+        , uint32_t old_glue
         , const uint32_t backtrack_level
         , uint32_t size
         , AtecedentData<uint16_t> resoltypes

--- a/src/sqlstats.h
+++ b/src/sqlstats.h
@@ -102,6 +102,7 @@ public:
         const Solver* solver
         , uint64_t clid
         , uint32_t glue
+        , uint32_t old_glue
         , uint32_t backtrack_level
         , uint32_t size
         , AtecedentData<uint16_t> resoltypes


### PR DESCRIPTION
Created a variable old_glue in handle_conflict. It passes through function calls and reaches dump_clause_stats to get stored in clauseStats table in the database.