### PR TITLE
Minor Pycryptosat Improvements

### DIFF
--- a/python/src/pycryptosat.cpp.in
+++ b/python/src/pycryptosat.cpp.in
@@ -1027,10 +1027,6 @@ static PyObject* get_conflict(Solver *self)
 
 /*************************** Method definitions *************************/
 
-static PyMethodDef module_methods[] = {
-    {NULL, NULL, 0, NULL}  /* Sentinel - marks the end of this structure */
-};
-
 static PyMethodDef Solver_methods[] = {
     {"solve",     (PyCFunction) solve,       METH_VARARGS | METH_KEYWORDS, solve_doc},
     {"add_clause",(PyCFunction) add_clause,  METH_VARARGS | METH_KEYWORDS, add_clause_doc},
@@ -1055,22 +1051,6 @@ Solver_dealloc(Solver* self)
     Py_TYPE(self)->tp_free ((PyObject*) self);
 }
 
-static PyObject *
-Solver_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
-{
-    Solver *self;
-
-    self = (Solver *)type->tp_alloc(type, 0);
-    if (self != NULL) {
-        setup_solver(self, args, kwds);
-        if (self->cmsat == NULL) {
-            Py_DECREF(self);
-            return NULL;
-        }
-    }
-    return (PyObject *)self;
-}
-
 static int
 Solver_init(Solver *self, PyObject *args, PyObject *kwds)
 {
@@ -1084,16 +1064,6 @@ Solver_init(Solver *self, PyObject *args, PyObject *kwds)
     }
     return 0;
 }
-
-static PyMemberDef Solver_members[] = {
-    /*{"first", T_OBJECT_EX, offsetof(Noddy, first), 0,
-     "first name"},
-    {"last", T_OBJECT_EX, offsetof(Noddy, last), 0,
-     "last name"},
-    {"number", T_INT, offsetof(Noddy, number), 0,
-     "noddy number"},*/
-    {NULL}  /* Sentinel */
-};
 
 static PyTypeObject pycryptosat_SolverType = {
     PyVarObject_HEAD_INIT(NULL, 0) /*ob_size*/
@@ -1124,7 +1094,7 @@ static PyTypeObject pycryptosat_SolverType = {
     0,                          /* tp_iter */
     0,                          /* tp_iternext */
     Solver_methods,             /* tp_methods */
-    Solver_members,             /* tp_members */
+    0,                          /* tp_members */
     0,                          /* tp_getset */
     0,                          /* tp_base */
     0,                          /* tp_dict */
@@ -1132,8 +1102,6 @@ static PyTypeObject pycryptosat_SolverType = {
     0,                          /* tp_descr_set */
     0,                          /* tp_dictoffset */
     (initproc)Solver_init,      /* tp_init */
-    0,                          /* tp_alloc */
-    Solver_new,                 /* tp_new */
 };
 
 MODULE_INIT_FUNC(pycryptosat)
@@ -1153,7 +1121,7 @@ MODULE_INIT_FUNC(pycryptosat)
         MODULE_NAME,            /* m_name */
         MODULE_DOC,             /* m_doc */
         -1,                     /* m_size */
-        module_methods,         /* m_methods */
+        NULL,                   /* m_methods */
         NULL,                   /* m_reload */
         NULL,                   /* m_traverse */
         NULL,                   /* m_clear */
@@ -1162,7 +1130,7 @@ MODULE_INIT_FUNC(pycryptosat)
 
     m = PyModule_Create(&moduledef);
     #else
-    m = Py_InitModule3(MODULE_NAME, module_methods, MODULE_DOC);
+    m = Py_InitModule3(MODULE_NAME, NULL, MODULE_DOC);
     #endif
 
     // Return NULL on Python3 and on Python2 with MODULE_INIT_FUNC macro

--- a/python/src/pycryptosat.cpp.in
+++ b/python/src/pycryptosat.cpp.in
@@ -1172,15 +1172,17 @@ MODULE_INIT_FUNC(pycryptosat)
         return NULL;
     }
 
-    Py_INCREF(&pycryptosat_SolverType);
-    PyModule_AddObject(m, "Solver", (PyObject *)&pycryptosat_SolverType);
-    PyModule_AddObject(m, "__version__", PyUnicode_FromString("${CMS_FULL_VERSION}"));
-
-    if (PyErr_Occurred())
-    {
-        PyErr_SetString(PyExc_ImportError, "pycryptosat: initialisation failed");
-        Py_DECREF(m);
-        m = NULL;
+    // Add the version string so users know what version of CryptoMiniSat
+    // they're using.
+    if (PyModule_AddStringConstant(m, "__version__", "${CMS_FULL_VERSION}") == -1) {
+        return NULL;
     }
+
+    // Add the Solver type.
+    Py_INCREF(&pycryptosat_SolverType);
+    if (PyModule_AddObject(m, "Solver", (PyObject *)&pycryptosat_SolverType)) {
+        return NULL;
+    }
+
     return m;
 }


### PR DESCRIPTION
I opened #563 since it seemed like separate changes than these and I've had them for a while when I started looking at this. 

I found the performance of Python to be a bit slow for walking circuits prior to giving them to `pycryptosat`, so I've been improving `cmsh` by using `SATSolver *` from CryptoMiniSat's C++ API. I'm now working on adding my own Python bindings for the native component into Python for `cmsh`. At any rate, I decided to check out what you were doing in `pycryptosat`. 

I found a weird crash:

```python3
import pycryptosat
cls = pycryptosat.Solver
inst = cls.__new__(cls)
    
inst.add_clauses([[1], [-1]])
# ^ SEGFAULT
```

This is because `self->cmsat` is NULL when `add_clauses` is called. If you run this in `gdb`, you see that [`Solver_new`](https://github.com/msoos/cryptominisat/blob/master/python/src/pycryptosat.cpp.in#L1058-L1072) simply isn't getting called, so `setup_solver` isn't either. Explicitly calling the `__init__` function seems to work though:

```python3
import pycryptosat
cls = pycryptosat.Solver
inst = cls.__new__(cls)
cls.__init__(inst)
    
inst.add_clauses([[1], [-1]])
```

I'm inclined to chalk this off as the desired behavior and note that `__init__` should always be called with the `pycryptosat.Solver` object. It might be nice to raise an exception rather than segfault though.

@msoos What do you think about explicitly raising an error when the solver hasn't been initialized in any of the instance methods?

---

Attached are also a few other improvements and simplifications. Some of these come from looking at other modules such as [`_csv from cpython`](https://github.com/python/cpython/blob/master/Modules/_csv.c). 