### PR TITLE
Cleanup pycryptosat initialization

### DIFF
--- a/python/src/pycryptosat.cpp.in
+++ b/python/src/pycryptosat.cpp.in
@@ -1168,19 +1168,22 @@ MODULE_INIT_FUNC(pycryptosat)
     // Return NULL on Python3 and on Python2 with MODULE_INIT_FUNC macro
     // In pure Python2: return nothing.
     if (!m) {
-        Py_XDECREF(m);
         return NULL;
     }
 
-    Py_INCREF(&pycryptosat_SolverType);
-    PyModule_AddObject(m, "Solver", (PyObject *)&pycryptosat_SolverType);
-    PyModule_AddObject(m, "__version__", PyUnicode_FromString("${CMS_FULL_VERSION}"));
-
-    if (PyErr_Occurred())
-    {
-        PyErr_SetString(PyExc_ImportError, "pycryptosat: initialisation failed");
+    // Add the version string so users know what version of CryptoMiniSat
+    // they're using.
+    if (PyModule_AddStringConstant(m, "__version__", "${CMS_FULL_VERSION}") == -1) {
         Py_DECREF(m);
-        m = NULL;
+        return NULL;
     }
+
+    // Add the Solver type.
+    Py_INCREF(&pycryptosat_SolverType);
+    if (PyModule_AddObject(m, "Solver", (PyObject *)&pycryptosat_SolverType)) {
+        Py_DECREF(m);
+        return NULL;
+    }
+
     return m;
 }


### PR DESCRIPTION
These changes help to make `pycryptosat` conform to common practices in
other Python/C API modules, such as those in `cpython`. There are three changes in this commit. 

1. Use `PyModule_AddStringConstant` to add `__version__` to the module.
2. Rewrite error checking to occur on the call and not at the end, allowing us to do (3).
3. Remove error mangling if an error occurred "somewhere".

I'm not sure why the diff looks like how it does, but that's fine.

Python since at least 2.5 has supported the `PyModule_AddStringConstant`
helper. Various modules in `cpython` use it (such as [`_csv`](https://github.com/python/cpython/blob/master/Modules/_csv.c#L1641-L1644), [`zlib`](https://github.com/python/cpython/blob/master/Modules/zlibmodule.c#L1458), [`parser`](https://github.com/python/cpython/blob/master/Modules/parsermodule.c#L1189-L1190)) instead of
explicitly allocating the object for `__version__` like `pycryptosat` does.

Then we move error handling to `PyModule_AddStringConstant` and `PyModule_AddObject`,
checking their return code on failure. This will preserve any original `PyErr`
which did occur. Also, detect failure at the time it happens instead of all at
once at the end. 

Not checking `PyErr_Occurred()` is another common practice -- if one did
occur, presumably a more descriptive PyErr String would already be set.
The only reason for doing so would be to hide the actual PyErr message
for some reason. 

`Signed-off-by: Alexander Scheel <alexander.m.scheel@gmail.com>`