### PR TITLE
Remove Solver_members definition

### DIFF
--- a/python/src/pycryptosat.cpp.in
+++ b/python/src/pycryptosat.cpp.in
@@ -1085,16 +1085,6 @@ Solver_init(Solver *self, PyObject *args, PyObject *kwds)
     return 0;
 }
 
-static PyMemberDef Solver_members[] = {
-    /*{"first", T_OBJECT_EX, offsetof(Noddy, first), 0,
-     "first name"},
-    {"last", T_OBJECT_EX, offsetof(Noddy, last), 0,
-     "last name"},
-    {"number", T_INT, offsetof(Noddy, number), 0,
-     "noddy number"},*/
-    {NULL}  /* Sentinel */
-};
-
 static PyTypeObject pycryptosat_SolverType = {
     PyVarObject_HEAD_INIT(NULL, 0) /*ob_size*/
     "pycryptosat.Solver",       /*tp_name*/
@@ -1124,7 +1114,7 @@ static PyTypeObject pycryptosat_SolverType = {
     0,                          /* tp_iter */
     0,                          /* tp_iternext */
     Solver_methods,             /* tp_methods */
-    Solver_members,             /* tp_members */
+    0,                          /* tp_members */
     0,                          /* tp_getset */
     0,                          /* tp_base */
     0,                          /* tp_dict */


### PR DESCRIPTION
The contents of `Solver_members` seem to be left over from a different
time and seem unrelated to CryptoMiniSat. Remove them. In the
`pycryptosat_SolverType` struct, set the `tp_members` pointer to `NULL`.

`Signed-off-by: Alexander Scheel <alexander.m.scheel@gmail.com>`