### PR TITLE
Remove unused Solver_new implementation

### DIFF
--- a/python/src/pycryptosat.cpp.in
+++ b/python/src/pycryptosat.cpp.in
@@ -1055,22 +1055,6 @@ Solver_dealloc(Solver* self)
     Py_TYPE(self)->tp_free ((PyObject*) self);
 }
 
-static PyObject *
-Solver_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
-{
-    Solver *self;
-
-    self = (Solver *)type->tp_alloc(type, 0);
-    if (self != NULL) {
-        setup_solver(self, args, kwds);
-        if (self->cmsat == NULL) {
-            Py_DECREF(self);
-            return NULL;
-        }
-    }
-    return (PyObject *)self;
-}
-
 static int
 Solver_init(Solver *self, PyObject *args, PyObject *kwds)
 {
@@ -1132,8 +1116,6 @@ static PyTypeObject pycryptosat_SolverType = {
     0,                          /* tp_descr_set */
     0,                          /* tp_dictoffset */
     (initproc)Solver_init,      /* tp_init */
-    0,                          /* tp_alloc */
-    Solver_new,                 /* tp_new */
 };
 
 MODULE_INIT_FUNC(pycryptosat)


### PR DESCRIPTION
(I made it four; this was the remaining change from #564 not covered by the other three PRs I opened this morning). 

`Solver_new` is unused due to its replacement with [`PyType_GenericNew`](https://github.com/msoos/cryptominisat/commit/9a04102ea72b6b9c0d82c7981dc5928af375a5c8#diff-f302d59ffbb0986caa6e74370a6de11fR320). This
means that `Solver_new` is dead code. According to the Python
[documentation](https://docs.python.org/3/reference/datamodel.html#object.__new__), `__new__` should initialize a new instance of a type,
similar to the following C code:

```c
my_ptr = calloc(...);
MyType_init(my_ptr, ...);
return my_ptr
```

However, `PyType_GenericNew` doesn't call our `tp_init` on the newly
created object. This means the resulting instance isn't initialized,
forcing us to initialize it before calling into the SATSolver API.

This means that `pycryptosat` objects differ from some other classes in Python:
```python3
cls = dict
my_dict = cls.__new__(cls)
my_dict[3] = 4
print(my_dict) # {3: 4}
```

For some more complex classes, it'll raise an exception instead and it appears that `__init__` isn't always called (this also happens with, e.g., `json.JSONEncoder`):

```python3
>>> import Crypto.Hash.MD5
>>> cls = Crypto.Hash.MD5.MD5Hash
>>> obj = cls.__new__(cls, data=b"The quick brown fox jumps over the lazy dog")
>>> obj.hexdigest()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python3.7/site-packages/Crypto/Hash/hashalgo.py", line 90, in hexdigest
    return self._hash.hexdigest()
AttributeError: 'MD5Hash' object has no attribute '_hash'
```

IMO, that these pure-Python classes don't call `__init__` with the arguments passed to `__new__` is a bug from my reading of the Python documentation.

At any rate, when we do the same with `pycryptosat`, we get a Segfault since `SATSolver *cmsat` is `NULL`:

```python3
import pycryptosat
cls = pycryptosat.Solver
inst = cls.__new__(cls)
inst.add_clauses([[1], [-1]]) # Segmentation fault (core dumped)
```

With the following backtrace:

```c
#0  CMSat::SATSolver::nVars (this=0x0) at /home/cipherboy/GitHub/cipherboy/cryptominisat/src/cryptominisat.cpp:867
#1  0x00007fffea7568c3 in add_clauses (self=0x7fffea77d0c0, args=<optimized out>, kwds=<optimized out>) at /home/cipherboy/GitHub/cipherboy/cryptominisat/build/pycryptosat/src/pycryptosat.cpp:512
#2  0x00007ffff7b96968 in _PyMethodDef_RawFastCallKeywords (method=<optimized out>, self=<pycryptosat.Solver at remote 0x7fffea77d0c0>, args=<optimized out>, nargs=<optimized out>, kwnames=0x0) at /usr/src/debug/python3-3.7.3-3.fc30.x86_64/Objects/call.c:690
#3  0x00007ffff7bcee9d in _PyMethodDescr_FastCallKeywords (descrobj=<method_descriptor at remote 0x7fffea76c630>, args=0x7fffea911b68, nargs=2, kwnames=0x0) at /usr/src/debug/python3-3.7.3-3.fc30.x86_64/Objects/descrobject.c:288
#4  0x00007ffff7bcf02b in call_function (pp_stack=0x7fffffffd1c0, oparg=<optimized out>, kwnames=0x0) at /usr/src/debug/python3-3.7.3-3.fc30.x86_64/Python/ceval.c:4593
#5  0x00007ffff7c0cae5 in _PyEval_EvalFrameDefault (f=<optimized out>, throwflag=<optimized out>) at /usr/src/debug/python3-3.7.3-3.fc30.x86_64/Python/ceval.c:3110
<snip>
```

(you might have some luck breaking on `type_call`). 

There's a couple of things we can do, which I want your input on which we should do:

0. Do nothing.
1. Recognize that `Solver_new` is dead code and quit pretending it isn't, documenting (via this PR) that `__new__` doesn't work correctly with our class.
2. Try and fix it such that `Solver_new` can be called instead of `PyType_GenericNew`.
3. Throw an exception when we call a Solver method and the Solver isn't yet initialized.
4. Initialize the Solver with default parameters when we call a Solver method and it isn't yet initialize. 

At any rate, I think we can both agree that a segfault in Python is not the desired behavior. (i.e., 0). 2 would be best, but I'm stumped unless you have any ideas; hence me filing 1 to get the discussion going. 4 seems like surprising behavior and not something we want. 3 seems like a good addition to 1 if we can't get 2 to work, especially since not every type behaves according to the Python documentation.


(I've not yet found a scenario in which calling `__new__` seems particularly handy involving `pycryptosat`).

Thoughts?

`Signed-off-by: Alexander Scheel <alexander.m.scheel@gmail.com>`