### PR TITLE
Fix extra semicolons in various places and enable the corresponding warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,7 @@ if (NOT WIN32)
         add_cxx_flag_if_supported("-Winit-self")
         add_cxx_flag_if_supported("-Wparentheses")
         add_cxx_flag_if_supported("-Wunreachable-code")
+        add_cxx_flag_if_supported("-Wextra-semi-stmt")
         add_cxx_flag_if_supported("-ggdb3")
 
         # Apparently needed before OS X Maverics (2013)

--- a/src/cryptominisat.cpp
+++ b/src/cryptominisat.cpp
@@ -659,7 +659,7 @@ void add_xor_clause_to_log(const std::vector<unsigned>& vars, bool rhs, std::ofs
 {
     if (vars.size() == 0) {
         if (rhs) {
-            (*file) << "0" << endl;;
+            (*file) << "0" << endl;
         }
     } else {
         if (!rhs) {
@@ -668,7 +668,7 @@ void add_xor_clause_to_log(const std::vector<unsigned>& vars, bool rhs, std::ofs
         for(unsigned var: vars) {
             (*file) << (var+1) << " ";
         }
-        (*file) << " 0" << endl;;
+        (*file) << " 0" << endl;
     }
 }
 

--- a/src/distillerlong.cpp
+++ b/src/distillerlong.cpp
@@ -146,7 +146,7 @@ bool DistillerLong::go_through_clauses(
         if (cl.getdistilled()) {
             *j++ = *i;
             continue;
-        };
+        }
         cl.set_distilled(true);
         runStats.checkedClauses++;
         assert(cl.size() > 2);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1388,7 +1388,7 @@ void Main::dump_decisions_for_model()
     if (conf.verbosity) {
         cout << "c size of get_decisions_reaching_model: "
         << solver->get_decisions_reaching_model().size()
-        << endl;;
+        << endl;
     }
     for(const Lit l: solver->get_decisions_reaching_model()) {
         decfile << l << " 0" << endl;

--- a/src/main_exe.cpp
+++ b/src/main_exe.cpp
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
     } catch (CMSat::TooLongClauseError& e) {
         std::cerr << "ERROR! Too long clause inserted" << std::endl;
         exit(-1);
-    };
+    }
 
     return ret;
 }

--- a/src/occsimplifier.cpp
+++ b/src/occsimplifier.cpp
@@ -144,7 +144,7 @@ void OccSimplifier::save_on_var_memory()
     cl_to_free_later.shrink_to_fit();
 
     elim_calc_need_update.shrink_to_fit();
-    blockedClauses.shrink_to_fit();;
+    blockedClauses.shrink_to_fit();
 }
 
 void OccSimplifier::print_blocked_clauses_reverse() const
@@ -3137,7 +3137,6 @@ double OccSimplifier::Stats::total_time(OccSimplifier* occs) const
         + occs->sub_str->get_stats().strengthenTime
         + occs->bvestats_global.timeUsed
         + occs->bva->get_stats().time_used;
-        ;
 }
 
 void OccSimplifier::Stats::clear()

--- a/src/searcher.cpp
+++ b/src/searcher.cpp
@@ -1235,7 +1235,7 @@ lbool Searcher::search()
                 && !clean_clauses_if_needed()
             ) {
                 return l_False;
-            };
+            }
             reduce_db_if_needed();
             dec_ret = new_decision<update_bogoprops>();
             if (dec_ret != l_Undef) {

--- a/src/sls.cpp
+++ b/src/sls.cpp
@@ -56,7 +56,7 @@ lbool SLS::run_walksat()
     if (mem_needed_mb < maxmem) {
         lbool ret = walksat.main();
         return ret;
-    };
+    }
 
     if (solver->conf.verbosity) {
         cout << "c [sls] would need "
@@ -76,7 +76,7 @@ lbool SLS::run_yalsat()
     if (mem_needed_mb < maxmem) {
         lbool ret = yalsat.main();
         return ret;
-    };
+    }
 
     if (solver->conf.verbosity) {
         cout << "c [sls] would need "

--- a/src/solverconf.h
+++ b/src/solverconf.h
@@ -88,7 +88,7 @@ inline std::string getNameOfRestartType(Restart rest_type)
 
         default:
             assert(false && "Unknown clause cleaning type?");
-    };
+    }
 }
 
 inline std::string getNameOfCleanType(ClauseClean clauseCleaningType)
@@ -103,7 +103,7 @@ inline std::string getNameOfCleanType(ClauseClean clauseCleaningType)
         default:
             assert(false && "Unknown clause cleaning type?");
             std::exit(-1);
-    };
+    }
 }
 
 class GaussConf

--- a/src/varupdatehelper.h
+++ b/src/varupdatehelper.h
@@ -119,7 +119,7 @@ inline void updateBySwap(T& toUpdate, T2& seen, const vector< uint32_t >& mapper
                 seen.at(mapper.at(var)) = 1;
                 break;
             }
-        };
+        }
     }
 
     //clear seen

--- a/src/xorfinder.cpp
+++ b/src/xorfinder.cpp
@@ -359,7 +359,7 @@ void XorFinder::findXorMatch(watch_subarray_const occ, const Lit wlit)
             //there is no point in using this clause as a base for another XOR
             //because exactly the same things will be found.
             if (cl.size() == poss_xor.getSize()) {
-                cl.stats.marked_clause = true;;
+                cl.stats.marked_clause = true;
             }
 
             xor_find_time_limit -= cl.size()/4+1;


### PR DESCRIPTION
As part of some different work, I played with warnings that are currently not in use by CMSat and noticed that `-Wextra-semi-stmt` leads to 131 extra warnings, most of which were caused by 3 instances in header files that are then included by many different TUs.