### PR TITLE
Provide const overloads for get_sum_{conflicts,decisions,propagations}

### DIFF
--- a/src/cryptominisat.cpp
+++ b/src/cryptominisat.cpp
@@ -1069,6 +1069,15 @@ DLL_PUBLIC uint64_t SATSolver::get_sum_conflicts()
     return conlf;
 }
 
+DLL_PUBLIC uint64_t SATSolver::get_sum_conflicts() const
+{
+    uint64_t total_conflicts = 0;
+    for (Solver const* s : data->solvers) {
+        total_conflicts += s->sumConflicts;
+    }
+    return total_conflicts;
+}
+
 DLL_PUBLIC uint64_t SATSolver::get_sum_propagations()
 {
     uint64_t props = 0;
@@ -1079,6 +1088,15 @@ DLL_PUBLIC uint64_t SATSolver::get_sum_propagations()
     return props;
 }
 
+DLL_PUBLIC uint64_t SATSolver::get_sum_propagations() const
+{
+    uint64_t total_propagations = 0;
+    for (Solver const* s : data->solvers) {
+        total_propagations += s->sumPropStats.propagations;
+    }
+    return total_propagations;
+}
+
 DLL_PUBLIC uint64_t SATSolver::get_sum_decisions()
 {
     uint64_t dec = 0;
@@ -1087,6 +1105,15 @@ DLL_PUBLIC uint64_t SATSolver::get_sum_decisions()
         dec += s.sumSearchStats.decisions;
     }
     return dec;
+}
+
+DLL_PUBLIC uint64_t SATSolver::get_sum_decisions() const
+{
+    uint64_t total_decisions = 0;
+    for (Solver const* s : data->solvers) {
+        total_decisions += s->sumSearchStats.decisions;
+    }
+    return total_decisions;
 }
 
 DLL_PUBLIC uint64_t SATSolver::get_last_conflicts()

--- a/src/cryptominisat.h.in
+++ b/src/cryptominisat.h.in
@@ -132,8 +132,11 @@ namespace CMSat {
         ////////////////////////////
 
         uint64_t get_sum_conflicts(); //get total number of conflicts of all time of all threads
+        uint64_t get_sum_conflicts() const; //!< Return sum of all conflicts since construction across all the threads
         uint64_t get_sum_propagations();  //get total number of propagations of all time made by all threads
+        uint64_t get_sum_propagations() const; //!< Returns sum of all propagations since construction across all the threads
         uint64_t get_sum_decisions(); //get total number of decisions of all time made by all threads
+        uint64_t get_sum_decisions() const; //!< Returns sum of all decisions since construction across all the threads
 
         void print_stats() const; //print solving stats. Call after solve()/simplify()
         void set_drat(std::ostream* os, bool set_ID); //set drat to ostream, e.g. stdout or a file


### PR DESCRIPTION
As per #581, this provides const overloads for the existing functions. If there is no fear of breaking external dependencies, the non-const overloads can be removed, otherwise they can be marked as deprecated and removed in the next major release.

Closes #581