### PR TITLE
Remove 'register' storage specifier from variable declarations in MT

### DIFF
--- a/src/MersenneTwister.h
+++ b/src/MersenneTwister.h
@@ -184,7 +184,7 @@ inline MTRand::uint32 MTRand::randInt()
 	if( left == 0 ) reload();
 	--left;
 
-	register uint32 s1;
+	uint32 s1;
 	s1 = *pNext++;
 	s1 ^= (s1 >> 11);
 	s1 ^= (s1 <<  7) & 0x9d2c5680UL;
@@ -229,9 +229,9 @@ inline void MTRand::seed( uint32 *const bigSeed, const uint32 seedLength )
 	// in each element are discarded.
 	// Just call seed() if you want to get array from /dev/urandom
 	initialize(19650218UL);
-	register int i = 1;
-	register uint32 j = 0;
-	register int k = ( N > (int)seedLength ? N : (int)seedLength );
+	int i = 1;
+	uint32 j = 0;
+	int k = ( N > (int)seedLength ? N : (int)seedLength );
 	for( ; k; --k )
 	{
 		state[i] =
@@ -266,9 +266,9 @@ inline void MTRand::seed()
 	if( urandom )
 	{
 		uint32 bigSeed[N];
-		register uint32 *s = bigSeed;
-		register int i = N;
-		register bool success = true;
+		uint32 *s = bigSeed;
+		int i = N;
+		bool success = true;
 		while( success && i-- )
 			success = fread( s++, sizeof(uint32), 1, urandom );
 		fclose(urandom);
@@ -286,9 +286,9 @@ inline void MTRand::initialize( const uint32 seed )
 	// See Knuth TAOCP Vol 2, 3rd Ed, p.106 for multiplier.
 	// In previous versions, most significant bits (MSBs) of the seed affect
 	// only MSBs of the state array.  Modified 9 Jan 2002 by Makoto Matsumoto.
-	register uint32 *s = state;
-	register uint32 *r = state;
-	register int i = 1;
+	uint32 *s = state;
+	uint32 *r = state;
+	int i = 1;
 	*s++ = seed & 0xffffffffUL;
 	for( ; i < N; ++i )
 	{
@@ -302,8 +302,8 @@ inline void MTRand::reload()
 {
 	// Generate N new values in state
 	// Made clearer and faster by Matthew Bellew (matthew.bellew@home.com)
-	register uint32 *p = state;
-	register int i;
+	uint32 *p = state;
+	int i;
 	for( i = N - M; i--; ++p )
 		*p = twist( p[M], p[0], p[1] );
 	for( i = M; --i; ++p )
@@ -342,9 +342,9 @@ inline MTRand::uint32 MTRand::hash( time_t t, clock_t c )
 
 inline void MTRand::save( uint32* saveArray ) const
 {
-	register uint32 *sa = saveArray;
-	register const uint32 *s = state;
-	register int i = N;
+	uint32 *sa = saveArray;
+	const uint32 *s = state;
+	int i = N;
 	for( ; i--; *sa++ = *s++ ) {}
 	*sa = left;
 }
@@ -352,9 +352,9 @@ inline void MTRand::save( uint32* saveArray ) const
 
 inline void MTRand::load( uint32 *const loadArray )
 {
-	register uint32 *s = state;
-	register uint32 *la = loadArray;
-	register int i = N;
+	uint32 *s = state;
+	uint32 *la = loadArray;
+	int i = N;
 	for( ; i--; *s++ = *la++ ) {}
 	left = *la;
 	pNext = &state[N-left];
@@ -363,8 +363,8 @@ inline void MTRand::load( uint32 *const loadArray )
 
 inline std::ostream& operator<<( std::ostream& os, const MTRand& mtrand )
 {
-	register const MTRand::uint32 *s = mtrand.state;
-	register int i = mtrand.N;
+	const MTRand::uint32 *s = mtrand.state;
+	int i = mtrand.N;
 	for( ; i--; os << *s++ << "\t" ) {}
 	return os << mtrand.left;
 }
@@ -372,8 +372,8 @@ inline std::ostream& operator<<( std::ostream& os, const MTRand& mtrand )
 
 inline std::istream& operator>>( std::istream& is, MTRand& mtrand )
 {
-	register MTRand::uint32 *s = mtrand.state;
-	register int i = mtrand.N;
+	MTRand::uint32 *s = mtrand.state;
+	int i = mtrand.N;
 	for( ; i--; is >> *s++ ) {}
 	is >> mtrand.left;
 	mtrand.pNext = &mtrand.state[mtrand.N-mtrand.left];


### PR DESCRIPTION
The `register` keyword as a storage specifier keyword has been
deprecated in C++11 and C++17 actually removes it from the language
completely, pending future reuse.

The rationale is that it is a weak hint that is pretty much ignored
by all major modern compilers, and the effect of the specifier is
implicit in C++ anyway.

This also fixes all of the `-Wdeprecated-register` instances in CMSat.
