### PR TITLE
Don't use bool as a number

### DIFF
--- a/src/walksat.cpp
+++ b/src/walksat.cpp
@@ -679,7 +679,6 @@ void WalkSAT::update_and_print_statistics_end_try()
         integer_sum_x += x;
         sum_x = (double)integer_sum_x;
         sum_r += r;
-        mean_r = ((double)sum_r) / (double)found_solution;
         x = 0;
         r = 0;
     }
@@ -711,9 +710,8 @@ void WalkSAT::print_statistics_final()
         cout << "c [walksat] total elapsed seconds = " <<  totalTime << endl;
         cout << "c [walksat] num tries: " <<  numtry  << endl;
         cout << "c [walksat] avg flips per second = " << ratio_for_stat(totalflip, totalTime) << endl;
-        cout << "c [walksat] final success rate = " << stats_line_percent(found_solution, numtry)  << endl;
-        cout << "c [walksat] avg length successful tries = %" <<
-               ratio_for_stat(totalsuccessflip,found_solution) << endl;
+        cout << "c [walksat] final success rate = " << stats_line_percent(1, numtry)  << endl;
+        cout << "c [walksat] avg length successful tries = %" << totalsuccessflip << endl;
         if (found_solution) {
             cout << "c [walksat] total success flip = " << totalsuccessflip << endl;
             cout << "c [walksat] flips = " << totalflip << endl;

--- a/src/walksat.h
+++ b/src/walksat.h
@@ -160,14 +160,13 @@ private:
     uint32_t lowbad;                  /* lowest number of bad clauses during try */
     int64_t totalflip = 0;        /* total number of flips in all tries so far */
     int64_t totalsuccessflip = 0; /* total number of flips in all tries which succeeded so far */
-    bool found_solution = 0;       /* total found solutions */
+    bool found_solution = false;       /* total found solutions */
     int64_t x;
     int64_t integer_sum_x = 0;
     double sum_x = 0.0;
     double seconds_per_flip;
     int r;
     int sum_r = 0;
-    double mean_r;
     double avgfalse;
     double sumfalse;
     double sumfalse_squared;


### PR DESCRIPTION
As it turns out, there were significant changes to `walksat.cpp` between the version we use (latest releaes), and current master. However, some places still used `found_solution` as a number, rather than as a boolean variable, so this fixes (most) of them.

Also removed a variable that was written to, but never read.

Fixes #589