### PR TITLE
Prevent an extra copy when iterating through map

### DIFF
--- a/src/varreplacer.cpp
+++ b/src/varreplacer.cpp
@@ -1252,8 +1252,7 @@ void VarReplacer::save_state(SimpleOutFile& f) const
     f.put_uint32_t(replacedVars);
 
     f.put_uint32_t(reverseTable.size());
-    for(const std::pair<uint32_t, vector<uint32_t> >& elem: reverseTable)
-    {
+    for(auto const& elem: reverseTable) {
         f.put_uint32_t(elem.first);
         f.put_vector(elem.second);
     }


### PR DESCRIPTION
The problem is that the entry type of a `std::map<K, V>` is
`pair<const K, V>`, rather than `pair<K, V>`. Because the latter
is constructible from the former via a copy constructor, the old
code compiled, but made an extra copy during iteration.