### PR TITLE
Properly forbid copies of SharedData::Spec

### DIFF
--- a/src/shareddata.h
+++ b/src/shareddata.h
@@ -44,9 +44,9 @@ class SharedData
                 data(new vector<Lit>)
             {}
 
-            Spec(const Spec&) {
-                assert(false);
-            }
+            Spec(const Spec&) = delete;
+            Spec& operator=(const Spec&) = delete;
+            
             Spec(Spec&& other)
             #ifndef _MSC_VER
             noexcept


### PR DESCRIPTION
This forbids the undesirable construct during compilation, instead of waiting to cause failure at runtime.

There are certain obscure cases where the old construct is the right choice involving `std::function` and other guaranteed-copyable wrappers, but since the code still compiles, it obviously is not the case here.