### PR TITLE
Reduce weak vtables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,7 @@ if (NOT WIN32)
         add_cxx_flag_if_supported("-Wparentheses")
         add_cxx_flag_if_supported("-Wunreachable-code")
         add_cxx_flag_if_supported("-Wextra-semi-stmt")
+        add_cxx_flag_if_supported("-Wweak-vtables")
         add_cxx_flag_if_supported("-ggdb3")
 
         # Apparently needed before OS X Maverics (2013)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,7 @@ endif()
 
 set(cryptoms_lib_files
     cnf.cpp
+    drat.cpp
     propengine.cpp
     varreplacer.cpp
     clausecleaner.cpp

--- a/src/drat.cpp
+++ b/src/drat.cpp
@@ -1,0 +1,25 @@
+/******************************************
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+***********************************************/
+
+#include "drat.h"
+
+namespace CMSat {
+    void Drat::flush() {}
+}

--- a/src/drat.h
+++ b/src/drat.h
@@ -93,9 +93,7 @@ struct Drat
     {
     }
 
-    virtual void flush()
-    {
-    }
+    virtual void flush();
 
     int buf_len;
     unsigned char* drup_buf = 0;

--- a/src/hyperengine.cpp
+++ b/src/hyperengine.cpp
@@ -30,6 +30,8 @@ HyperEngine::HyperEngine(const SolverConf *_conf, std::atomic<bool>* _must_inter
 {
 }
 
+HyperEngine::~HyperEngine() = default;
+
 Lit HyperEngine::propagate_bfs(const uint64_t timeout)
 {
     timedOutPropagateFull = false;

--- a/src/hyperengine.h
+++ b/src/hyperengine.h
@@ -36,6 +36,8 @@ namespace CMSat {
 
 class HyperEngine : public PropEngine {
 public:
+    ~HyperEngine() override;
+
     HyperEngine(const SolverConf *_conf, std::atomic<bool>* _must_interrupt_inter);
     size_t print_stamp_mem(size_t totalMem) const;
     size_t mem_used() const;

--- a/src/sqlstats.cpp
+++ b/src/sqlstats.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #include "sqlstats.h"
 using namespace CMSat;
 
+SQLStats::~SQLStats() = default;
 
 #ifndef _MSC_VER
 #include <fcntl.h>

--- a/src/sqlstats.h
+++ b/src/sqlstats.h
@@ -37,8 +37,7 @@ class SQLStats
 {
 public:
 
-    virtual ~SQLStats()
-    {}
+    virtual ~SQLStats();
 
     virtual void restart(
         const std::string& restart_type


### PR DESCRIPTION
This PR sweets out most instances of weak vtables.

A class has weak vtable when it has no out-of-line definitions of virtual functions. This means that the compiler cannot pick an authoritative TU to contain the class's vtable and RTTI structures. Because of this, the compiler has to emit all of this in every TU that touch the header, bloating the size of object files and increasing compilation times, and link times (because the linker has to deduplicate the vtables and RTTI structures).