### PR TITLE
Extend C API with set_verbosity and print_stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ scripts/fuzz/tmp_for_xor_to_cnf_*
 scripts/reconf/outfile*
 
 web/jquery-1.11.3.min.js
+/.vs

--- a/src/cryptominisat_c.cpp
+++ b/src/cryptominisat_c.cpp
@@ -121,4 +121,8 @@ extern "C"
     DLL_PUBLIC void cmsat_set_num_threads(SATSolver* self, unsigned n) NOEXCEPT_START {
         self->set_num_threads(n);
     } NOEXCEPT_END
+
+    DLL_PUBLIC void cmsat_set_verbosity(SATSolver* self, unsigned n) NOEXCEPT_START {
+        self->set_verbosity(n);
+    } NOEXCEPT_END
 }

--- a/src/cryptominisat_c.cpp
+++ b/src/cryptominisat_c.cpp
@@ -117,7 +117,11 @@ extern "C"
         return unwrap<slice_Lit>(self->get_conflict());
     } NOEXCEPT_END
 
-//Setup
+    DLL_PUBLIC void cmsat_print_stats(SATSolver* self) NOEXCEPT_START {
+        self->print_stats();
+    } NOEXCEPT_END
+    
+    //Setup
     DLL_PUBLIC void cmsat_set_num_threads(SATSolver* self, unsigned n) NOEXCEPT_START {
         self->set_num_threads(n);
     } NOEXCEPT_END

--- a/src/cryptominisat_c.cpp
+++ b/src/cryptominisat_c.cpp
@@ -117,7 +117,7 @@ extern "C"
         return unwrap<slice_Lit>(self->get_conflict());
     } NOEXCEPT_END
 
-    DLL_PUBLIC void cmsat_print_stats(SATSolver* self) NOEXCEPT_START {
+    DLL_PUBLIC void cmsat_print_stats(const SATSolver* self) NOEXCEPT_START {
         self->print_stats();
     } NOEXCEPT_END
     

--- a/src/cryptominisat_c.h.in
+++ b/src/cryptominisat_c.h.in
@@ -68,6 +68,8 @@ CMS_DLL_PUBLIC c_lbool cmsat_solve_with_assumptions(SATSolver* self, const c_Lit
 CMS_DLL_PUBLIC slice_lbool cmsat_get_model(const SATSolver* self) NOEXCEPT;
 CMS_DLL_PUBLIC slice_Lit cmsat_get_conflict(const SATSolver* self) NOEXCEPT;
 
+CMS_DLL_PUBLIC void cmsat_print_stats(const SATSolver* self) NOEXCEPT;
+
 CMS_DLL_PUBLIC void cmsat_set_num_threads(SATSolver* self, unsigned n) NOEXCEPT;
 CMS_DLL_PUBLIC void cmsat_set_verbosity(SATSolver* self, unsigned n) NOEXCEPT;
 

--- a/src/cryptominisat_c.h.in
+++ b/src/cryptominisat_c.h.in
@@ -69,6 +69,7 @@ CMS_DLL_PUBLIC slice_lbool cmsat_get_model(const SATSolver* self) NOEXCEPT;
 CMS_DLL_PUBLIC slice_Lit cmsat_get_conflict(const SATSolver* self) NOEXCEPT;
 
 CMS_DLL_PUBLIC void cmsat_set_num_threads(SATSolver* self, unsigned n) NOEXCEPT;
+CMS_DLL_PUBLIC void cmsat_set_verbosity(SATSolver* self, unsigned n) NOEXCEPT;
 
 #ifdef __cplusplus
 } // end extern c


### PR DESCRIPTION
Does what the title says. cmsat_set_verbosity is included in the C API.