### PR TITLE
Update documentation of the reconf parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -542,13 +542,13 @@ The following arguments to cmake configure the generated build artifacts. To use
 
 Trying different configurations
 -----
-Try solving using different reconfiguration values between 1..15 as per:
+Try solving using different reconfiguration values 3,4,6,7,12,13,14,15,16 as per:
 
 ```
-./cryptominisat5 --reconfat 0 --reconf 1 my_hard_problem.cnf
-./cryptominisat5 --reconfat 0 --reconf 2 my_hard_problem.cnf
+./cryptominisat5 --reconfat 0 --reconf 3 my_hard_problem.cnf
+./cryptominisat5 --reconfat 0 --reconf 4 my_hard_problem.cnf
 ...
-./cryptominisat5 --reconfat 0 --reconf 15 my_hard_problem.cnf
+./cryptominisat5 --reconfat 0 --reconf 16 my_hard_problem.cnf
 ```
 
 These configurations are designed to be relatively orthogonal. Check if any of them solve a lot faster. If it does, try using that for similar problems going forward. Please do come back to the author with what you have found to work best for you.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -745,7 +745,7 @@ void Main::add_supported_options()
     ("reconfat", po::value(&conf.reconfigure_at)->default_value(conf.reconfigure_at)
         , "Reconfigure after this many simplifications")
     ("reconf", po::value(&conf.reconfigure_val)->default_value(conf.reconfigure_val)
-        , "Reconfigure after some time to this solver configuration [0..15]")
+        , "Reconfigure after some time to this solver configuration [3,4,6,7,12,13,14,15,16]")
     ;
 
     hiddenOptions.add_options()

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -3390,6 +3390,7 @@ void Solver::reconfigure(int val)
         }
 
         default: {
+            //when this changes, don't forget to update README.markdown and the command line help (main.cpp)
             cout << "ERROR: Only reconfigure values of 3,4,6,7,12,13,14,15,16 are supported" << endl;
             exit(-1);
         }


### PR DESCRIPTION
In the current release, the documentation of the `reconf` parameter in the readme.md and command line help state that `reconf` can be set to 0..15. In fact, only the values 3,4,6,7,12,13,14,15,16 are supported.

This patch updates the documentation to tell users that values 3,4,6,7,12,13,14,15,16 are supported.

(Note 1: I didn't update the autotune-related python scripts to work with the new reconf values.)
(Note 2: Happy holidays!)