### PR TITLE
build: add osx 10.13 for cross compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,14 @@ env:
 matrix:
   include:
     - os: osx
-      osx_image: xcode11.3
+      osx_image: xcode10.1 # osx 10.13
+      compiler: clang
+      python: "3.7"
+      env:
+        - CMS_CONFIG=NORMAL
+
+    - os: osx
+      osx_image: xcode11.3 # osx 10.14.6
       compiler: clang
       python: "3.7"
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,13 @@ matrix:
       env:
         - CMS_CONFIG=NORMAL
 
+    - os: osx
+      osx_image: xcode11.4 # osx 10.15
+      compiler: clang
+      python: "3.7"
+      env:
+        - CMS_CONFIG=NORMAL
+
     - os: linux
       dist: bionic
       compiler: gcc


### PR DESCRIPTION
relates to https://github.com/msoos/cryptominisat/issues/617

Adding osx 10.13 into build matrix.