### PR TITLE
A patch to address #625

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,18 @@ matrix:
       env:
         - CMS_CONFIG=STATIC
 
+    - os: linux
+      dist: bionic
+      compiler: gcc
+      python: "3.7"
+      addons:
+         apt:
+            packages: mingw-w64
+      env:
+        - CMS_CONFIG=MINGW32
+        - CC=x86_64-w64-mingw32-gcc-posix
+        - CXX=x86_64-w64-mingw32-g++-posix
+
     #- os: linux
       #compiler: gcc
       #env: COVERITY_SCAN=1 CMS_CONFIG=NORMAL

--- a/scripts/travis-cmake.sh
+++ b/scripts/travis-cmake.sh
@@ -245,6 +245,21 @@ case $CMS_CONFIG in
             "${SOURCE_DIR}"
     ;;
 
+    MINGW32)
+        rm -rf ${SOURCE_DIR}/utils/gtest
+        if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libboost-program-options-dev; fi
+        eval cmake -DENABLE_PYTHON_INTERFACE=OFF \
+                   -DNOVALGRIND=ON \
+                   -DNOZLIB=ON \
+                   -DONLY_SIMPLE=ON \
+                   -DSTATICCOMPILE=ON \
+                   -DIPASIR=ON \
+                   -MIT=ON \
+                   -DCMAKE_BUILD_TYPE=Release \
+                   -D CMAKE_SYSTEM_NAME=Windows \
+                   "${SOURCE_DIR}"
+    ;;   
+
     *)
         echo "\"${CMS_CONFIG}\" configuration not recognised"
         exit 1

--- a/src/packedmatrix.h
+++ b/src/packedmatrix.h
@@ -50,7 +50,7 @@ public:
 
     ~PackedMatrix()
     {
-        #ifdef _MSC_VER
+        #ifdef _WIN32
         _aligned_free((void*)mp);
         #else
         free(mp);
@@ -62,7 +62,7 @@ public:
         num_cols = num_cols / 64 + (bool)(num_cols % 64);
         if (numRows*(numCols+1) < (int)num_rows*((int)num_cols+1)) {
             size_t size = sizeof(int64_t) * num_rows*(num_cols+1);
-            #ifdef _MSC_VER
+            #ifdef _WIN32
             _aligned_free((void*)mp);
             mp =  (int64_t*)_aligned_malloc(size, 16);
             #else
@@ -85,7 +85,7 @@ public:
     {
         if (numRows*(numCols+1) < b.numRows*(b.numCols+1)) {
             size_t size = sizeof(int64_t) * b.numRows*(b.numCols+1);
-            #ifdef _MSC_VER
+            #ifdef _WIN32
             _aligned_free((void*)mp);
             mp =  (int64_t*)_aligned_malloc(size, 16);
             #else


### PR DESCRIPTION
I have also added a travis option to test a build using a mingw32 cross-compiler on linux, but the travis script also builds other things like drat-trim, and I don't know how to prevent this. The tests are also disabled since it is not possible to run the produced exe file on linux. Ideally, a mingw32 build should run on windows, but I do not have a windows machine to test the setup.