### PR TITLE
Bugfixes for ipasir_val() and ipasir_assume()

### DIFF
--- a/src/ipasir.cpp
+++ b/src/ipasir.cpp
@@ -92,6 +92,17 @@ DLL_PUBLIC void ipasir_release (void * solver)
     delete s;
 }
 
+namespace
+{
+void ensure_var_created(MySolver& s, Lit lit)
+{
+    if (lit.var() >= s.solver->nVars()) {
+        const uint32_t toadd = lit.var() - s.solver->nVars() + 1;
+        s.solver->new_vars(toadd);
+    }
+}
+}
+
 /**
  * Add the given literal into the currently added clause
  * or finalize the clause with a 0.  Clauses added this way
@@ -116,10 +127,7 @@ DLL_PUBLIC void ipasir_add (void * solver, int lit_or_zero)
         s->clause.clear();
     } else {
         Lit lit(std::abs(lit_or_zero)-1, lit_or_zero < 0);
-        if (lit.var() >= s->solver->nVars()) {
-            const uint32_t toadd = lit.var() - s->solver->nVars() + 1;
-            s->solver->new_vars(toadd);
-        }
+        ensure_var_created(*s, lit);
         s->clause.push_back(lit);
     }
 }
@@ -136,6 +144,7 @@ DLL_PUBLIC void ipasir_assume (void * solver, int lit)
 {
     MySolver* s = (MySolver*)solver;
     Lit lit_cms(std::abs(lit)-1, lit < 0);
+    ensure_var_created(*s, lit_cms);
     s->assumptions.push_back(lit_cms);
 }
 

--- a/src/ipasir.cpp
+++ b/src/ipasir.cpp
@@ -196,15 +196,17 @@ DLL_PUBLIC int ipasir_val (void * solver, int lit)
     MySolver* s = (MySolver*)solver;
     assert(s->solver->okay());
 
-    const uint32_t var = std::abs(lit)-1;
-    lbool val = s->solver->get_model()[var];
+    const int ipasirVar = std::abs(lit);
+    const uint32_t cmVar = ipasirVar-1;
+    lbool val = s->solver->get_model()[cmVar];
+
     if (val == l_Undef) {
         return 0;
     }
     if (val == l_False) {
-        lit = -1*lit;
+        return -ipasirVar;
     }
-    return lit;
+    return ipasirVar;
 }
 
 /**

--- a/tests/ipasir_test.cpp
+++ b/tests/ipasir_test.cpp
@@ -367,6 +367,22 @@ TEST(ipasir_interface, assump_clears)
     ipasir_release(s);
 }
 
+TEST(ipasir_interface, ipasir_val)
+{
+    void* s = ipasir_init();
+    ipasir_add(s, -7);
+    ipasir_add(s, 0);
+    ipasir_add(s, 8);
+    ipasir_add(s, 0);
+    int ret = ipasir_solve(s);
+    ASSERT_EQ(ret, 10);
+
+    EXPECT_EQ(ipasir_val(s, -7), -7);
+    EXPECT_EQ(ipasir_val(s, 7), -7);
+    EXPECT_EQ(ipasir_val(s, -8), 8);
+    EXPECT_EQ(ipasir_val(s, 8), 8);
+}
+
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/tests/ipasir_test.cpp
+++ b/tests/ipasir_test.cpp
@@ -367,6 +367,18 @@ TEST(ipasir_interface, assump_clears)
     ipasir_release(s);
 }
 
+TEST(ipasir_interface, ipasir_assump_beyond_problemvars)
+{
+    void* s = ipasir_init();
+    ipasir_add(s, -7);
+    ipasir_add(s, 0);
+    ipasir_assume(s, 10);
+    int ret = ipasir_solve(s);
+    ASSERT_EQ(ret, 10);
+
+    EXPECT_EQ(ipasir_val(s, 10), 10);
+}
+
 TEST(ipasir_interface, ipasir_val)
 {
     void* s = ipasir_init();


### PR DESCRIPTION
This PR fixes two issues with the IPASIR implementation:

* **`ipasir_val` for negative literals:** Currently, `ipasir_val(s, lit)` returns `-lit` if the variable `v` of `lit` is assigned `false`, `lit` if `v` is assigned `true` and 0 otherwise. However, the IPASIR spec requires checking the assignment of the literal, not that of the variable. The current implementation works fine for positive literals, but returns invalid values for negative ones (flipping `lit` when the variable of `lit` is assigned `false` even when `lit` < 0).
**New behavior:** `ipasir_val(s, lit)` returns `-lit` if `lit` is assigned `false`; `lit` if `lit` is assigned `true` and 0 otherwise. 

* **`ipasir_assume` for literals not occurring in any clause:** Cryptominisat refuses assumptions not occurring in any clause added up to the next `ipasir_solve()` call. There is no such restriction in the IPASIR spec on the literals that can be passed to `ipasir_assume()`, though.
**New behavior:** `ipasir_assume(s, lit)` creates new variables as needed.

I made a single PR for these two issues to avoid merge conflicts in ipasir_test.cpp, but I could split this one if you prefer separate PRs. 
