### PR TITLE
Quote some flags in python/CMakeLists.txt

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -45,9 +45,9 @@ else()
     set(PY_INSTALL_PREFIX "--prefix=${CMAKE_INSTALL_PREFIX}")
 endif()
 
-string(REPLACE "\n" " " PY_C_CONFIG ${PY_C_CONFIG})
-string(REPLACE "\n" " " PY_LD_CONFIG ${PY_LD_CONFIG})
-string(REPLACE "\n" " " PY_LINKFORSHARED_CONFIG ${PY_LINKFORSHARED_CONFIG})
+string(REPLACE "\n" " " PY_C_CONFIG "${PY_C_CONFIG}")
+string(REPLACE "\n" " " PY_LD_CONFIG "${PY_LD_CONFIG}")
+string(REPLACE "\n" " " PY_LINKFORSHARED_CONFIG "${PY_LINKFORSHARED_CONFIG}")
 
 message(STATUS "Python CFLAGS:  '${PY_C_CONFIG}'")
 message(STATUS "Python LDFLAGS: '${PY_LD_CONFIG}'")


### PR DESCRIPTION
CMake complained about COMPARE needing 4 arguments when I tried to generate using MSYS; looks like the problem is that one of the Python flags is an empty string and CMake thinks the argument is missing. Quoting the flags fixes it.