### PR TITLE
Make exported target have an include dir

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -180,6 +180,11 @@ add_library(cryptominisat5
     ${cryptoms_lib_files}
     cryptominisat.cpp
 )
+# Make sure the exported target has the include directory set
+target_include_directories(cryptominisat5 PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
 
 GENERATE_EXPORT_HEADER(cryptominisat5
          BASE_NAME cryptominisat5


### PR DESCRIPTION
This PR addresses an issue that arises if one installs `cryptominisat5` to a custom location outside of the standard search paths (e.g. when building as a dependency of another projection within an cmake `ExternalProject`).
What I would like to do is use libcryptominisat5 via `find_package(cryptominisat5)` and `target_link_libraries(MyTarget cryptominisat5)`. This fails right now, because the `cryptominisat5` target does not define its include directories, thus one needs to add the include directory manually (either to `MyTarget` or `cryptominisat5`.

This PR fixes this issue by setting the public include directory for the `cryptominisat5` target.