### PR TITLE
Switch __GNUC__ to __GLIBC__ to support musl

### DIFF
--- a/src/main_exe.cpp
+++ b/src/main_exe.cpp
@@ -27,7 +27,7 @@ THE SOFTWARE.
 
 int main(int argc, char** argv)
 {
-    #if defined(__GNUC__) && defined(__linux__)
+    #if defined(__GLIBC__) && defined(__linux__)
     feenableexcept(FE_INVALID   |
                    FE_DIVBYZERO |
                    FE_OVERFLOW


### PR DESCRIPTION
Resolves second issue discussed in #650 where musl wouldn't compile since `feenableexcept` isn't available there. Attempted to use _GNU_SOURCE as mentioned by @andrewvaughanj but was not successful. 

Used this method to fix in downstream here: https://github.com/JuliaPackaging/Yggdrasil/pull/2911 where I'm packaging CMS using https://binarybuilder.org/ for Julia!