### PR TITLE
Modernize Boost usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -754,6 +754,8 @@ endif()
 if(NOT Boost_FOUND)
     set(ONLY_SIMPLE ON)
     message(STATUS "Only building executable with few command-line options because the boost program_options library were not available")
+else()
+    message(STATUS "Boost -- found at library: ${Boost_LIBRARIES}")
 endif()
 
 # -----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 11)
 
@@ -754,10 +754,6 @@ endif()
 if(NOT Boost_FOUND)
     set(ONLY_SIMPLE ON)
     message(STATUS "Only building executable with few command-line options because the boost program_options library were not available")
-else()
-    message(STATUS "Boost -- found at library: ${Boost_LIBRARIES}")
-    message(STATUS "Boost -- adding '${Boost_LIBRARY_DIRS}' to link directories")
-    link_directories(${Boost_LIBRARY_DIRS})
 endif()
 
 # -----------------------------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,11 +21,6 @@
 include_directories( ${PROJECT_SOURCE_DIR} )
 include_directories( ${BOSPHORUS_INCLUDE_DIRS} )
 
-if(Boost_FOUND)
-    include_directories(${Boost_INCLUDE_DIRS})
-endif()
-
-
 if (NOT WIN32)
     add_cxx_flag_if_supported("-Wno-bitfield-constant-conversion")
     #add_cxx_flag_if_supported("-Wduplicated-cond")
@@ -371,7 +366,7 @@ if (NOT ONLY_SIMPLE)
         RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}
         INSTALL_RPATH_USE_LINK_PATH TRUE)
     target_link_libraries(cryptominisat5-bin
-        ${Boost_LIBRARIES}
+        Boost::program_options
         ${cryptoms_exec_link_libs}
     )
     install(TARGETS cryptominisat5-bin


### PR DESCRIPTION
In this PR I modernized Boost usage by using [imported targets](https://cmake.org/cmake/help/latest/module/FindBoost.html#imported-targets). But the feature was introduced in CMake 3.5, so I bumped the version. But KLEE uses [the same version](https://github.com/klee/klee/blob/0ba95edbad26fe70c8132f0731778d94f9609874/CMakeLists.txt#L13), so I hope it's okay :)

Made the same PR for [stp](https://github.com/stp/stp/pull/418).