### PR TITLE
Issue #665 solution count print

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2009-2020 Authors of CryptoMiniSat, see AUTHORS file
+Copyright (C) 2009-2022 Authors of CryptoMiniSat, see AUTHORS file
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -1457,6 +1457,19 @@ int Main::solve()
     printResultFunc(&cout, false, ret);
     if (resultfile) {
         printResultFunc(resultfile, true, ret);
+    }
+    if (ret == l_True && max_nr_of_solutions > 1) {
+       // If ret is l_True then we must have hit the solution limit.
+       // Print final number of solutions when we hit the limit here
+       // as multi_solutions() doesn't. Don't print for a single solution.
+       if (conf.verbosity) {
+           cout
+           << "c Number of solutions found until now: "
+           << std::setw(6) << max_nr_of_solutions
+           << endl
+           << "c maxsol reached"
+           << endl;
+       }
     }
 
     return correctReturnValue(ret);


### PR DESCRIPTION
Fixes #665

Print a solution count for the last solution.
For example
>c Number of solutions found until now:      2
>c maxsol reached

The message need to printed outside of multi_solutions() as multi_solutions returns with the last solution still to be printed,
and the message should be printed after the soliution, like for the other messages.
Also the new message is only printed when more than one solution is requested, to avoid clutter.
