### PR TITLE
python/setup.py.in: import sysconfig instead of importing it from distutils

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -27,7 +27,7 @@ import sys
 import os
 import platform
 from distutils.core import setup, Extension
-from distutils import sysconfig
+import sysconfig
 from distutils.cmd import Command
 
 __PACKAGE_VERSION__ = "0.2.0"
@@ -59,8 +59,8 @@ def _init_posix(init):
     Forces g++ instead of gcc on most systems
     credits to eric jones (eric@enthought.com) (found at Google Groups)
     """
-    def wrapper():
-        init()
+    def wrapper(vars):
+        init(vars)
 
         config_vars = sysconfig.get_config_vars()  # by reference
         if config_vars["MACHDEP"].startswith("sun"):


### PR DESCRIPTION
setuptools 61 dropped sysconfig module

Ref: https://github.com/stamparm/pcapy-ng/commit/f6ce5248f78ac0a247d76e48cff152f4e3f26482
Bug: https://bugs.gentoo.org/836684

Signed-off-by: Maciej Barć <xgqt@gentoo.org>
