### PR TITLE
Add <algorithm> header to assump_test.cpp

### DIFF
--- a/tests/assump_test.cpp
+++ b/tests/assump_test.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #include "cryptominisat5/cryptominisat.h"
 #include "src/solverconf.h"
 #include <vector>
+#include <algorithm>
 using std::vector;
 using namespace CMSat;
 


### PR DESCRIPTION
Without this header, std::sort is not included directly in this header file, but transitively over the stp/googletest distribution, in the `include/gtest/internal/gtest-port.h` file, included by `include/gtest/internal/gtest-string.h`, included by `include/gtest/gtest.h`.

This change makes it easier to use a different GTest implementation, which is easier for some package management mechanisms.