### PR TITLE
Catch boost errors to avoid core dump in case of wrong command line parameters

### DIFF
--- a/src/main_exe.cpp
+++ b/src/main_exe.cpp
@@ -50,6 +50,9 @@ int main(int argc, char** argv)
     } catch (CMSat::TooLongClauseError& e) {
         std::cerr << "ERROR! Too long clause inserted" << std::endl;
         exit(-1);
+    } catch (const boost::program_options::error& ex) {
+        std::cerr << "Error: " << ex.what() << std::endl;
+        exit(-1);
     }
 
     return ret;


### PR DESCRIPTION
Catch boost errors to avoid core dump in case of wrong command line parameters