### PR TITLE
Include <cstdint> explicitly where required

### DIFF
--- a/src/alg.h
+++ b/src/alg.h
@@ -20,6 +20,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #ifndef Alg_h
 #define Alg_h
 
+#include <cstdint>
 #include <iostream>
 #include "solvertypes.h"
 #include "watched.h"

--- a/src/boundedqueue.h
+++ b/src/boundedqueue.h
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include <cassert>
 #include <vector>
 #include <cstring>
+#include <cstdint>
 #include <sstream>
 #include <iomanip>
 

--- a/src/bva.h
+++ b/src/bva.h
@@ -27,6 +27,7 @@ THE SOFTWARE.
 #include "watched.h"
 #include "clause.h"
 #include "touchlist.h"
+#include <cstdint>
 #include <vector>
 using std::vector;
 

--- a/src/cardfinder.h
+++ b/src/cardfinder.h
@@ -27,6 +27,7 @@ THE SOFTWARE.
 #include <set>
 #include <iostream>
 #include <algorithm>
+#include <cstdint>
 #include <set>
 #include <limits>
 #include "xor.h"

--- a/src/ccnr.h
+++ b/src/ccnr.h
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #ifndef CCNR_H
 #define CCNR_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include "ccnr_mersenne.h"

--- a/src/cl_predictors_abs.h
+++ b/src/cl_predictors_abs.h
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #ifndef _CLPREDICTORS_ABST_H__
 #define _CLPREDICTORS_ABST_H__
 
+#include <cstdint>
 #include <vector>
 #include <cassert>
 #include <string>

--- a/src/clabstraction.h
+++ b/src/clabstraction.h
@@ -24,6 +24,8 @@ THE SOFTWARE.
 #ifndef __CL_ABSTRACTION__H__
 #define __CL_ABSTRACTION__H__
 
+#include <cstdint>
+
 typedef uint32_t cl_abst_type;
 static const int cl_abst_modulo = 29;
 

--- a/src/clause.h
+++ b/src/clause.h
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #define CLAUSE_H
 
 #include <cstdio>
+#include <cstdint>
 #include <vector>
 #include <sys/types.h>
 #include <string.h>

--- a/src/vmtf.h
+++ b/src/vmtf.h
@@ -22,6 +22,7 @@ THE SOFTWARE.
 
 #ifndef VMTF_H
 
+#include <cstdint>
 #include <vector>
 #include <cstdint>
 #include "constants.h"

--- a/src/watcharray.h
+++ b/src/watcharray.h
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 #include "watched.h"
 #include "Vec.h"
+#include <cstdint>
 #include <vector>
 
 namespace CMSat {

--- a/src/watcharray_handrolled.h
+++ b/src/watcharray_handrolled.h
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #ifndef __WATCHARRAY_H__
 #define __WATCHARRAY_H__
 
+#include <cstdint>
 #include <stdlib.h>
 #include "watched.h"
 #include <vector>

--- a/src/watched.h
+++ b/src/watched.h
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include "cloffset.h"
 #include "solvertypes.h"
 
+#include <cstdint>
 #include <limits>
 #include <string.h>
 

--- a/src/xor.h
+++ b/src/xor.h
@@ -25,6 +25,7 @@ THE SOFTWARE.
 
 #include "solvertypes.h"
 
+#include <cstdint>
 #include <vector>
 #include <set>
 #include <iostream>

--- a/src/xorfinder.h
+++ b/src/xorfinder.h
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #ifndef _XORFINDER_H_
 #define _XORFINDER_H_
 
+#include <cstdint>
 #include <vector>
 #include <set>
 #include <iostream>


### PR DESCRIPTION
These files all assume the definition of types from <cstdint> but were getting those definitions transitively. GCC trunk (GCC13) no longer provides <cstdint> definitions transitively.