### PR TITLE
src/mpicosat/mpicosat.c: fix path to unistd.h

### DIFF
--- a/src/mpicosat/mpicosat.c
+++ b/src/mpicosat/mpicosat.c
@@ -8148,7 +8148,7 @@ picosat_stats (PS * ps)
 #else
 #include <sys/time.h>
 #include <sys/resource.h>
-#include <sys/unistd.h>
+#include <unistd.h>
 #endif
 
 double


### PR DESCRIPTION
A build failure with musl libc was reported on the Gentoo bug tracker:

  https://bugs.gentoo.org/895118

The root cause is that the file sys/unistd.h is not included with musl. The POSIX standard include for unistd.h is simply <unistd.h>:

  https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/unistd.h.html

and musl does provide that. Even in glibc, the sys-prefixed path is simply a wrapper:

```
$ cat /usr/include/sys/unistd.h
#include <unistd.h>
```

This commit changes the line,

```c
#include <sys/unistd.h>
```

to

```c
#include <unistd.h>
```

which should be more portable. In particular, it works with musl.