### PR TITLE
Update build instructions to install needed shared libraries

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -37,13 +37,14 @@ cd cadical
 git checkout mate-only-libraries-1.8.0
 ./configure
 make
+sudo cp build/libcadical.so /usr/lib
 cd ..
 
 git clone https://github.com/meelgroup/cadiback
 cd cadiback
 git checkout mate
 ./configure
-make
+make install
 cd ..
 
 git clone https://github.com/msoos/cryptominisat


### PR DESCRIPTION
It seems that the default build of cryptominisat5 used shared libraries that weren't installed using these build instructions.

I've added the (scary) minimal stuff I did that makes it work right away.