### PR TITLE
Add missing #include <array> in oracle.h

### DIFF
--- a/src/oracle/oracle.h
+++ b/src/oracle/oracle.h
@@ -35,6 +35,7 @@
 #define oclv2(x) do {} while(0)
 #endif
 
+#include <array>
 using std::array;
 
 namespace sspp {


### PR DESCRIPTION
GCC requires an explicit `#include <array>` for `std::array`. Clang finds it transitively through other headers, masking the issue on macOS.

This fixes the build failure on Linux with GCC 12+ (e.g. Homebrew on Linux):
```
oracle/oracle.h:37:12: error: 'array' has not been declared in 'std'
   37 | using std::array;
```

ref: https://github.com/Homebrew/homebrew-core/pull/275892
ref: https://github.com/Homebrew/homebrew-core/actions/runs/23947655260/job/69847929972