### PR TITLE
C API additions, fix add_bnn_clause_outside edge case

### DIFF
--- a/src/cryptominisat_c.cpp
+++ b/src/cryptominisat_c.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #include "cryptominisat_c.h"
 #include "constants.h"
 #include "cryptominisat.h"
+#include <cstdint>
 
 
 // C wrappers for SATSolver so that it can be used from other languages (e.g. Rust)
@@ -96,6 +97,10 @@ extern "C"
         return self->add_xor_clause(wrap(vars, num_vars), rhs);
     } NOEXCEPT_END
 
+    DLL_PUBLIC bool cmsat_add_bnn_clause(SATSolver* self, const c_Lit* lits, size_t num_lits, int cutoff) NOEXCEPT_START {
+        return self->add_bnn_clause(wrap(fromc(lits), num_lits), cutoff);
+    } NOEXCEPT_END
+
     DLL_PUBLIC void cmsat_new_vars(SATSolver* self, const size_t n) NOEXCEPT_START {
         self->new_vars(n);
     } NOEXCEPT_END
@@ -166,5 +171,17 @@ extern "C"
 
     DLL_PUBLIC void cmsat_set_max_time(SATSolver* self, double max_time) NOEXCEPT_START {
         self->set_max_time(max_time);
+    } NOEXCEPT_END
+
+    DLL_PUBLIC void cmsat_set_max_confl(SATSolver* self, uint64_t max_confl) NOEXCEPT_START {
+        self->set_max_confl(max_confl);
+    } NOEXCEPT_END
+
+    DLL_PUBLIC void cmsat_set_timeout_all_calls(SATSolver* self, double secs) NOEXCEPT_START {
+        self->set_timeout_all_calls(secs);
+    } NOEXCEPT_END
+
+    DLL_PUBLIC void cmsat_interrupt_asap(SATSolver* self) NOEXCEPT_START {
+        self->interrupt_asap();
     } NOEXCEPT_END
 }

--- a/src/cryptominisat_c.h
+++ b/src/cryptominisat_c.h
@@ -63,6 +63,7 @@ CMS_DLL_PUBLIC void cmsat_free(SATSolver* s) NOEXCEPT;
 CMS_DLL_PUBLIC unsigned cmsat_nvars(const SATSolver* self) NOEXCEPT;
 CMS_DLL_PUBLIC bool cmsat_add_clause(SATSolver* self, const c_Lit* lits, size_t num_lits) NOEXCEPT;
 CMS_DLL_PUBLIC bool cmsat_add_xor_clause(SATSolver* self, const unsigned* vars, size_t num_vars, bool rhs) NOEXCEPT;
+CMS_DLL_PUBLIC bool cmsat_add_bnn_clause(SATSolver* self, const c_Lit* lits, size_t num_lits, int cutoff) NOEXCEPT;
 CMS_DLL_PUBLIC void cmsat_new_vars(SATSolver* self, const size_t n) NOEXCEPT;
 
 CMS_DLL_PUBLIC c_lbool cmsat_solve(SATSolver* self) NOEXCEPT;
@@ -86,6 +87,9 @@ CMS_DLL_PUBLIC void set_up_for_arjun(SATSolver* self) NOEXCEPT;
 CMS_DLL_PUBLIC void cmsat_set_yes_comphandler(SATSolver* self) NOEXCEPT;
 CMS_DLL_PUBLIC c_lbool cmsat_simplify(SATSolver* self, const c_Lit* assumptions, size_t num_assumptions) NOEXCEPT;
 CMS_DLL_PUBLIC void cmsat_set_max_time(SATSolver* self, double max_time) NOEXCEPT;
+CMS_DLL_PUBLIC void cmsat_interrupt_asap(SATSolver* self) NOEXCEPT;
+CMS_DLL_PUBLIC void cmsat_set_max_confl(SATSolver* self, uint64_t max_confl) NOEXCEPT;
+CMS_DLL_PUBLIC void cmsat_set_timeout_all_calls(SATSolver* self, double secs) NOEXCEPT;
 
 #ifdef __cplusplus
 } // end extern c

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -2770,8 +2770,10 @@ bool Solver::add_bnn_clause_outside( const vector<Lit>& lits, const int32_t cuto
 
     vector<Lit> lits2(lits);
     add_clause_helper(lits2);
-    out = map_outer_to_inter(out);
-    out = varReplacer->get_lit_replaced_with(out);
+    if (out != lit_Undef) {
+        out = map_outer_to_inter(out);
+        out = varReplacer->get_lit_replaced_with(out);
+    }
     add_bnn_clause_inter(lits2, cutoff, out);
 
     return ok;


### PR DESCRIPTION
Made a few more methods accessible from the C API
- `set_max_confl` 
- `set_timeout_all_calls`
- `interrupt_asap`
- `add_bnn_clause`

Small fix for crash when `add_bnn_clause_outside` is called with `out == lit_Undef` 