### PR TITLE
Make Threads PRIVATE in cryptominisat5; declare GMP as public dep in CMake config (fixes #820)

### DIFF
--- a/cmake/cryptominisat5Config-buildtree.cmake.in
+++ b/cmake/cryptominisat5Config-buildtree.cmake.in
@@ -1,4 +1,11 @@
 # Config file for the Build-tree cryptominisat5 package (not relocatable).
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+find_dependency(PkgConfig)
+if(NOT TARGET PkgConfig::GMP)
+    pkg_check_modules(GMP REQUIRED IMPORTED_TARGET gmp)
+endif()
+
 set(CRYPTOMINISAT5_INCLUDE_DIRS "@CMAKE_CURRENT_BINARY_DIR@/include")
 include("${CMAKE_CURRENT_LIST_DIR}/cryptominisat5Targets.cmake")
 set(CRYPTOMINISAT5_LIBRARIES cryptominisat5)

--- a/cmake/cryptominisat5Config-buildtree.cmake.in
+++ b/cmake/cryptominisat5Config-buildtree.cmake.in
@@ -1,6 +1,5 @@
 # Config file for the Build-tree cryptominisat5 package (not relocatable).
 include(CMakeFindDependencyMacro)
-find_dependency(Threads)
 find_dependency(PkgConfig)
 if(NOT TARGET PkgConfig::GMP)
     pkg_check_modules(GMP REQUIRED IMPORTED_TARGET gmp)

--- a/cryptominisat5Config.cmake.in
+++ b/cryptominisat5Config.cmake.in
@@ -2,7 +2,6 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Threads)
 find_dependency(PkgConfig)
 if(NOT TARGET PkgConfig::GMP)
     pkg_check_modules(GMP REQUIRED IMPORTED_TARGET gmp)

--- a/cryptominisat5Config.cmake.in
+++ b/cryptominisat5Config.cmake.in
@@ -1,6 +1,13 @@
 # Config file for the cryptominisat5 package.
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+find_dependency(PkgConfig)
+if(NOT TARGET PkgConfig::GMP)
+    pkg_check_modules(GMP REQUIRED IMPORTED_TARGET gmp)
+endif()
+
 set_and_check(CRYPTOMINISAT5_INCLUDE_DIRS "@PACKAGE_CRYPTOMINISAT5_INSTALL_INCLUDEDIR@")
 include("${CMAKE_CURRENT_LIST_DIR}/cryptominisat5Targets.cmake")
 set(CRYPTOMINISAT5_LIBRARIES cryptominisat5)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -267,15 +267,15 @@ if(FINAL_PREDICTOR)
     )
 endif()
 
-# indicate that we depend on pthread, and compile in the actual library
+# pthread is an implementation detail; GMP leaks through solvertypesmini.h
 target_link_libraries(cryptominisat5
     PRIVATE
         ${cryptoms_lib_link_libs}
         ${LOUVAIN_COMMUNITIES_LIBRARIES}
         cadiback
         cadical
-    PUBLIC
         Threads::Threads
+    PUBLIC
         PkgConfig::GMP
 )
 


### PR DESCRIPTION
## Summary
- `Threads::Threads` was linked as **PUBLIC** on the `cryptominisat5` target but doesn't need to be — the public headers don't expose any pthread types. The only thread-adjacent reference is `std::atomic<bool>*` in `cryptominisat.h` (header-only, no libpthread linkage). Moved it to `PRIVATE`.
- `PkgConfig::GMP` *is* genuinely public — `solvertypesmini.h:32` does `#include <gmpxx.h>` and uses `mpz_class`/`mpq_class` in inline code. Added `find_dependency(PkgConfig)` + `pkg_check_modules(GMP REQUIRED IMPORTED_TARGET gmp)` (gated on the target not already existing) to both `cryptominisat5Config.cmake.in` and the build-tree variant, so downstream `find_package(cryptominisat5)` resolves it automatically.

Net effect for the issue reporter: downstream consumers no longer need `find_package(Threads)` at all, because cryptominisat5 no longer publicly exposes that dependency.

Fixes #820.

## Test plan
- [x] `cmake <src>` configures cleanly with the new `target_link_libraries` split.
- [x] `cmake --build . --target cryptominisat5` links successfully (`libcryptominisat5.so` built).
- [x] Toy downstream project doing `find_package(cryptominisat5 REQUIRED)` + `target_link_libraries(... cryptominisat5)` reaches the generate phase without any undefined `Threads::Threads` or `PkgConfig::GMP` errors.
- [ ] Maintainer to sanity-check on a clean `cmake --install` consumed from outside the build tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)