### PR TITLE
Add Windows MSYS2/MinGW wheel builds to python-wheels CI

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         # Each runner builds for its native architecture.
         # Linux aarch64 uses a native ARM GitHub-hosted runner.
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-15-intel]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-15-intel, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -29,6 +29,29 @@ jobs:
         if: contains(matrix.os, 'macos')
         run: |
           brew install gmp || true
+
+      - name: Set up MSYS2 (Windows)
+        if: contains(matrix.os, 'windows')
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-ninja
+            mingw-w64-x86_64-gmp
+            mingw-w64-x86_64-zlib
+            mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-ccache
+
+      - name: Add MinGW to PATH (Windows)
+        if: contains(matrix.os, 'windows')
+        shell: bash
+        run: |
+          echo "C:/msys64/mingw64/bin" >> $GITHUB_PATH
+          echo "CC=gcc" >> $GITHUB_ENV
+          echo "CXX=g++" >> $GITHUB_ENV
 
       - name: Cache ccache
         uses: actions/cache@v4
@@ -49,6 +72,10 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: native   # x86_64 on ubuntu-latest, aarch64 on ubuntu-24.04-arm
           CIBW_ARCHS_MACOS: native   # arm64 on macos-14, x86_64 on macos-15-intel
+          CIBW_ARCHS_WINDOWS: native # AMD64 on windows-latest
+          CIBW_ENVIRONMENT_WINDOWS: |
+            CMAKE_GENERATOR=Ninja
+            PKG_CONFIG_PATH=C:/msys64/mingw64/lib/pkgconfig
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -42,14 +42,20 @@ jobs:
             mingw-w64-x86_64-ninja
             mingw-w64-x86_64-gmp
             mingw-w64-x86_64-zlib
-            mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-pkgconf
             mingw-w64-x86_64-ccache
+
+      - name: Get MSYS2 MinGW prefix (Windows)
+        if: contains(matrix.os, 'windows')
+        shell: msys2 {0}
+        run: |
+          echo "MINGW_PREFIX=$(cygpath -m /mingw64)" >> $GITHUB_ENV
+          echo "MINGW_BIN=$(cygpath -m /mingw64)/bin" >> $GITHUB_ENV
 
       - name: Add MinGW to PATH (Windows)
         if: contains(matrix.os, 'windows')
-        shell: bash
         run: |
-          echo "C:/msys64/mingw64/bin" >> $GITHUB_PATH
+          echo "${{ env.MINGW_BIN }}" >> $GITHUB_PATH
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
 
@@ -75,7 +81,7 @@ jobs:
           CIBW_ARCHS_WINDOWS: native # AMD64 on windows-latest
           CIBW_ENVIRONMENT_WINDOWS: |
             CMAKE_GENERATOR=Ninja
-            PKG_CONFIG_PATH=C:/msys64/mingw64/lib/pkgconfig
+            PKG_CONFIG_PATH=${{ env.MINGW_PREFIX }}/lib/pkgconfig
             MSYS=winsymlinks:nativestrict
             SKBUILD_CMAKE_ARGS=-DBUILD_PYTHON_EXTENSION=ON;-DENABLE_TESTING=OFF;-DBUILD_SHARED_LIBS=OFF;-DSTATIC_BINARY=OFF;-DCMAKE_POSITION_INDEPENDENT_CODE=ON;-DIPASIR=OFF
 

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -80,6 +80,7 @@ jobs:
           CIBW_ARCHS_MACOS: native   # arm64 on macos-14, x86_64 on macos-15-intel
           CIBW_ARCHS_WINDOWS: native # AMD64 on windows-latest
           CIBW_ENVIRONMENT_WINDOWS: |
+            PATH=${{ env.MINGW_BIN }};$PATH
             CMAKE_GENERATOR=Ninja
             PKG_CONFIG_PATH=${{ env.MINGW_PREFIX }}/lib/pkgconfig
             MSYS=winsymlinks:nativestrict

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -76,6 +76,8 @@ jobs:
           CIBW_ENVIRONMENT_WINDOWS: |
             CMAKE_GENERATOR=Ninja
             PKG_CONFIG_PATH=C:/msys64/mingw64/lib/pkgconfig
+            MSYS=winsymlinks:nativestrict
+            SKBUILD_CMAKE_ARGS=-DBUILD_PYTHON_EXTENSION=ON;-DENABLE_TESTING=OFF;-DBUILD_SHARED_LIBS=OFF;-DSTATIC_BINARY=OFF;-DCMAKE_POSITION_INDEPENDENT_CODE=ON;-DIPASIR=OFF
 
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,11 @@ repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
 # GMP is not a macOS system library; brew installs it and delocate bundles it.
 before-all = "brew install gmp ccache || true"
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
+
+[tool.cibuildwheel.windows]
+# MinGW/MSYS2 toolchain (GCC, GMP, zlib, pkg-config) is installed by the
+# workflow step before cibuildwheel runs.  CMake uses the Ninja generator
+# with the MinGW compilers (set via CIBW_ENVIRONMENT_WINDOWS in the workflow).
+# delvewheel automatically bundles MinGW runtime DLLs (libstdc++, libgmp, etc.).
+test-command = "cd %TEMP% && pytest {project}/python/tests"
+repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -349,17 +349,30 @@ set(HEADER_DEST "${PROJECT_BINARY_DIR}/include/cryptominisat5")
 add_custom_target(CopyPublicHeaders_cryptominisat5 ALL)
 foreach(public_header ${cryptominisat5_public_headers})
     get_filename_component(HEADER_NAME ${public_header} NAME)
-    add_custom_command(TARGET CopyPublicHeaders_cryptominisat5 PRE_BUILD
-                       COMMAND ${CMAKE_COMMAND} -E make_directory
-                               "${HEADER_DEST}"
-                       COMMAND ${CMAKE_COMMAND} -E echo
-                       "Symlinking ${HEADER_NAME} to ${HEADER_DEST}"
-                       COMMAND ${CMAKE_COMMAND} -E remove
-                               "${HEADER_DEST}/${HEADER_NAME}"
-                       COMMAND ${CMAKE_COMMAND} -E create_symlink
-                               "${public_header}"
-                               "${HEADER_DEST}/${HEADER_NAME}"
-                      )
+    if(WIN32)
+        # Windows: use copy instead of symlink (symlinks require Developer Mode)
+        add_custom_command(TARGET CopyPublicHeaders_cryptominisat5 PRE_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E make_directory
+                                   "${HEADER_DEST}"
+                           COMMAND ${CMAKE_COMMAND} -E echo
+                           "Copying ${HEADER_NAME} to ${HEADER_DEST}"
+                           COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                                   "${public_header}"
+                                   "${HEADER_DEST}/${HEADER_NAME}"
+                          )
+    else()
+        add_custom_command(TARGET CopyPublicHeaders_cryptominisat5 PRE_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E make_directory
+                                   "${HEADER_DEST}"
+                           COMMAND ${CMAKE_COMMAND} -E echo
+                           "Symlinking ${HEADER_NAME} to ${HEADER_DEST}"
+                           COMMAND ${CMAKE_COMMAND} -E remove
+                                   "${HEADER_DEST}/${HEADER_NAME}"
+                           COMMAND ${CMAKE_COMMAND} -E create_symlink
+                                   "${public_header}"
+                                   "${HEADER_DEST}/${HEADER_NAME}"
+                          )
+    endif()
 endforeach()
 
 generate_export_header(cryptominisat5)
@@ -414,17 +427,30 @@ set(ORACLE_HEADER_DEST "${PROJECT_BINARY_DIR}/include/oracle")
 add_custom_target(CopyPublicHeaders_oracle ALL)
 foreach(public_header ${oracle_public_headers})
     get_filename_component(HEADER_NAME ${public_header} NAME)
-    add_custom_command(TARGET CopyPublicHeaders_oracle PRE_BUILD
-                       COMMAND ${CMAKE_COMMAND} -E make_directory
-                               "${ORACLE_HEADER_DEST}"
-                       COMMAND ${CMAKE_COMMAND} -E echo
-                       "Symlinking ${HEADER_NAME} to ${ORACLE_HEADER_DEST}"
-                       COMMAND ${CMAKE_COMMAND} -E remove
-                               "${ORACLE_HEADER_DEST}/${HEADER_NAME}"
-                       COMMAND ${CMAKE_COMMAND} -E create_symlink
-                               "${public_header}"
-                               "${ORACLE_HEADER_DEST}/${HEADER_NAME}"
-                      )
+    if(WIN32)
+        # Windows: use copy instead of symlink (symlinks require Developer Mode)
+        add_custom_command(TARGET CopyPublicHeaders_oracle PRE_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E make_directory
+                                   "${ORACLE_HEADER_DEST}"
+                           COMMAND ${CMAKE_COMMAND} -E echo
+                           "Copying ${HEADER_NAME} to ${ORACLE_HEADER_DEST}"
+                           COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                                   "${public_header}"
+                                   "${ORACLE_HEADER_DEST}/${HEADER_NAME}"
+                          )
+    else()
+        add_custom_command(TARGET CopyPublicHeaders_oracle PRE_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E make_directory
+                                   "${ORACLE_HEADER_DEST}"
+                           COMMAND ${CMAKE_COMMAND} -E echo
+                           "Symlinking ${HEADER_NAME} to ${ORACLE_HEADER_DEST}"
+                           COMMAND ${CMAKE_COMMAND} -E remove
+                                   "${ORACLE_HEADER_DEST}/${HEADER_NAME}"
+                           COMMAND ${CMAKE_COMMAND} -E create_symlink
+                                   "${public_header}"
+                                   "${ORACLE_HEADER_DEST}/${HEADER_NAME}"
+                          )
+    endif()
 endforeach()
 
 add_executable(oracle-bin


### PR DESCRIPTION
- Add windows-latest to the build matrix in python-wheels.yml
- Set up MSYS2 with MinGW toolchain (gcc, cmake, ninja, gmp, zlib, pkg-config, ccache)
- Add MinGW to PATH and set CC/CXX for cibuildwheel
- Configure CMAKE_GENERATOR=Ninja and PKG_CONFIG_PATH via CIBW_ENVIRONMENT_WINDOWS
- Add [tool.cibuildwheel.windows] to pyproject.toml with delvewheel repair and Windows-compatible test-command

Windows was already present in build.yml and release.yml but was never added to the Python wheel workflow. This uses the same MSYS2/MinGW approach.