### PR TITLE
Add python Ctrl+C handler

### DIFF
--- a/python/src/pycryptosat.cpp
+++ b/python/src/pycryptosat.cpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include <cassert>
 #include <algorithm>
 #include "../../src/cryptominisat.h"
+#include "../../src/signalcode.h"
 using namespace CMSat;
 
 #define MODULE_NAME "pycryptosat"
@@ -586,10 +587,12 @@ static PyObject* solve(Solver *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
+    solverToInterrupt = self->cmsat;
     lbool res;
     Py_BEGIN_ALLOW_THREADS      /* release GIL */
     res = self->cmsat->solve(&assumption_lits);
     Py_END_ALLOW_THREADS
+    solverToInterrupt = nullptr;
 
     self->cmsat->set_verbosity(self->verbose);
     self->cmsat->set_max_time(self->time_limit);
@@ -824,6 +827,9 @@ MODULE_INIT_FUNC(pycryptosat)
         Py_DECREF(m);
         return NULL;
     }
+
+    // Set up Ctrl+C (SIGINT) handler so long solve() calls can be aborted.
+    setup_signal_handler();
 
     return m;
 }

--- a/python/src/pycryptosat.cpp
+++ b/python/src/pycryptosat.cpp
@@ -589,10 +589,21 @@ static PyObject* solve(Solver *self, PyObject *args, PyObject *kwds)
     }
 
     solverToInterrupt = self->cmsat;
+
+    // Save Python's SIGINT handler and install ours for the duration
+    // of the solve.  g_python_lib tells SIGINT_handler to only set the
+    // interrupt flag rather than calling _exit().
+    g_python_lib = true;
+    sighandler_t prev_handler = signal(SIGINT, SIGINT_handler);
+
     lbool res;
     Py_BEGIN_ALLOW_THREADS      /* release GIL */
     res = self->cmsat->solve(&assumption_lits);
     Py_END_ALLOW_THREADS
+
+    // Restore Python's original SIGINT handler.
+    signal(SIGINT, prev_handler);
+    g_python_lib = false;
     solverToInterrupt = nullptr;
 
     self->cmsat->set_verbosity(self->verbose);
@@ -828,12 +839,6 @@ MODULE_INIT_FUNC(pycryptosat)
         Py_DECREF(m);
         return NULL;
     }
-
-    // Set up Ctrl+C (SIGINT) handler so long solve() calls can be aborted.
-    // g_python_lib tells SIGINT_handler not to call _exit() — in library
-    // mode we only set the interrupt flag and let the solver return l_Undef.
-    g_python_lib = true;
-    signal(SIGINT, SIGINT_handler);
 
     return m;
 }

--- a/python/src/pycryptosat.cpp
+++ b/python/src/pycryptosat.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 **********************************/
 
 #include <Python.h>
+#include <signal.h>
 #include <structmember.h>
 #include <limits>
 #include <cassert>
@@ -829,7 +830,10 @@ MODULE_INIT_FUNC(pycryptosat)
     }
 
     // Set up Ctrl+C (SIGINT) handler so long solve() calls can be aborted.
-    setup_signal_handler();
+    // g_python_lib tells SIGINT_handler not to call _exit() — in library
+    // mode we only set the interrupt flag and let the solver return l_Undef.
+    g_python_lib = true;
+    signal(SIGINT, SIGINT_handler);
 
     return m;
 }

--- a/python/src/pycryptosat.cpp
+++ b/python/src/pycryptosat.cpp
@@ -589,11 +589,7 @@ static PyObject* solve(Solver *self, PyObject *args, PyObject *kwds)
     }
 
     solverToInterrupt = self->cmsat;
-
-    // Save Python's SIGINT handler and install ours for the duration
-    // of the solve.  g_python_lib tells SIGINT_handler to only set the
-    // interrupt flag rather than calling _exit().
-    g_python_lib = true;
+    interrupt_only = true;
     sighandler_t prev_handler = signal(SIGINT, SIGINT_handler);
 
     lbool res;
@@ -601,9 +597,8 @@ static PyObject* solve(Solver *self, PyObject *args, PyObject *kwds)
     res = self->cmsat->solve(&assumption_lits);
     Py_END_ALLOW_THREADS
 
-    // Restore Python's original SIGINT handler.
     signal(SIGINT, prev_handler);
-    g_python_lib = false;
+    interrupt_only = false;
     solverToInterrupt = nullptr;
 
     self->cmsat->set_verbosity(self->verbose);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -376,7 +376,6 @@ add_executable(cryptominisat5-bin
     main.cpp
     main_common.cpp
     main_exe.cpp
-    signalcode.cpp
 )
 
 add_library(oracle

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -209,6 +209,7 @@ endif()
 add_library(cryptominisat5
     ${cryptoms_lib_files}
     cryptominisat.cpp
+    signalcode.cpp
 )
 
 set(CRYPTOMINISAT_COMMON_PRIVATE_INCLUDES

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,7 +46,6 @@ using namespace CMSat;
 using std::cout;
 using std::cerr;
 using std::endl;
-double wallclock_time_started = 0.0;
 
 struct WrongParam {
     WrongParam(const string& _param, const string& _msg) : param(_param) , msg(_msg) {}

--- a/src/main_exe.cpp
+++ b/src/main_exe.cpp
@@ -42,7 +42,7 @@ int main(int argc, char** argv)
         main.conf.verbStats = 2;
         main.parseCommandLine();
 
-        signal(SIGINT, SIGINT_handler);
+        signal(SIGINT, CMSat::SIGINT_handler);
         ret = main.solve();
     } catch (CMSat::TooManyVarsError& e) {
         std::cerr << "ERROR! Variable requested is far too large" << std::endl;

--- a/src/main_exe.cpp
+++ b/src/main_exe.cpp
@@ -42,7 +42,7 @@ int main(int argc, char** argv)
         main.conf.verbStats = 2;
         main.parseCommandLine();
 
-        setup_signal_handler();
+        signal(SIGINT, SIGINT_handler);
         ret = main.solve();
     } catch (CMSat::TooManyVarsError& e) {
         std::cerr << "ERROR! Variable requested is far too large" << std::endl;

--- a/src/main_exe.cpp
+++ b/src/main_exe.cpp
@@ -42,7 +42,7 @@ int main(int argc, char** argv)
         main.conf.verbStats = 2;
         main.parseCommandLine();
 
-        signal(SIGINT, SIGINT_handler);
+        setup_signal_handler();
         ret = main.solve();
     } catch (CMSat::TooManyVarsError& e) {
         std::cerr << "ERROR! Variable requested is far too large" << std::endl;

--- a/src/signalcode.cpp
+++ b/src/signalcode.cpp
@@ -41,6 +41,11 @@ using std::endl;
 
 void SIGINT_handler(int)
 {
+    // Re-register: on some platforms (MinGW, System V) signal() resets
+    // to SIG_DFL after invocation.  Without this, the second Ctrl+C
+    // kills the process instead of interrupting cleanly.
+    signal(SIGINT, SIGINT_handler);
+
     SATSolver* solver = solverToInterrupt;
     cout << "c " << endl;
     std::cerr << "*** INTERRUPTED ***" << endl;

--- a/src/signalcode.cpp
+++ b/src/signalcode.cpp
@@ -38,6 +38,7 @@ using namespace CMSat;
 
 SATSolver* solverToInterrupt;
 int need_clean_exit;
+double wallclock_time_started = 0.0;
 std::string redDumpFname;
 std::string irredDumpFname;
 

--- a/src/signalcode.cpp
+++ b/src/signalcode.cpp
@@ -28,6 +28,10 @@ THE SOFTWARE.
 #endif
 
 using namespace CMSat;
+using std::cout;
+using std::endl;
+
+namespace CMSat {
 
 SATSolver* solverToInterrupt;
 int need_clean_exit;
@@ -35,9 +39,6 @@ double wallclock_time_started = 0.0;
 bool g_python_lib = false;
 std::string redDumpFname;
 std::string irredDumpFname;
-
-using std::cout;
-using std::endl;
 
 void SIGINT_handler(int)
 {
@@ -79,3 +80,5 @@ void SIGINT_handler(int)
         #endif
     }
 }
+
+} // namespace CMSat

--- a/src/signalcode.cpp
+++ b/src/signalcode.cpp
@@ -27,58 +27,34 @@ THE SOFTWARE.
 #include <unistd.h>
 #endif
 
-#ifdef _WIN32
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <windows.h>
-#endif
-
 using namespace CMSat;
 
 SATSolver* solverToInterrupt;
 int need_clean_exit;
 double wallclock_time_started = 0.0;
+bool g_python_lib = false;
 std::string redDumpFname;
 std::string irredDumpFname;
 
 using std::cout;
 using std::endl;
 
-#ifdef _WIN32
-static BOOL WINAPI CtrlHandler(DWORD fdwCtrlType)
-{
-    if (fdwCtrlType == CTRL_C_EVENT || fdwCtrlType == CTRL_BREAK_EVENT) {
-        std::cerr << "*** INTERRUPTED ***" << std::endl;
-        if (solverToInterrupt) {
-            // Set the atomic interrupt flag; the solver's search loop
-            // will detect this, abort cleanly, return l_Undef, and the
-            // normal exit path will print stats.
-            solverToInterrupt->interrupt_asap();
-        } else {
-            // No solver yet (e.g. still parsing); just exit.
-            exit(1);
-        }
-        return TRUE;  // signal handled, don't call next handler
-    }
-    return FALSE;  // pass to next handler (logoff, shutdown, etc.)
-}
-#endif
-
-void setup_signal_handler()
-{
-#ifdef _WIN32
-    SetConsoleCtrlHandler(CtrlHandler, TRUE);
-#else
-    signal(SIGINT, SIGINT_handler);
-#endif
-}
-
 void SIGINT_handler(int)
 {
     SATSolver* solver = solverToInterrupt;
     cout << "c " << endl;
     std::cerr << "*** INTERRUPTED ***" << endl;
+
+    if (g_python_lib) {
+        // Library mode (Python): only set the interrupt flag, let the
+        // solver return l_Undef cleanly.  Do NOT call _exit() — that
+        // would kill the Python process.
+        if (solver) {
+            solver->interrupt_asap();
+        }
+        return;
+    }
+
     if (!redDumpFname.empty() || !irredDumpFname.empty() || need_clean_exit) {
         solver->interrupt_asap();
         std::cerr

--- a/src/signalcode.cpp
+++ b/src/signalcode.cpp
@@ -41,11 +41,6 @@ using std::endl;
 
 void SIGINT_handler(int)
 {
-    // Re-register: on some platforms (MinGW, System V) signal() resets
-    // to SIG_DFL after invocation.  Without this, the second Ctrl+C
-    // kills the process instead of interrupting cleanly.
-    signal(SIGINT, SIGINT_handler);
-
     SATSolver* solver = solverToInterrupt;
     cout << "c " << endl;
     std::cerr << "*** INTERRUPTED ***" << endl;

--- a/src/signalcode.cpp
+++ b/src/signalcode.cpp
@@ -27,6 +27,12 @@ THE SOFTWARE.
 #include <unistd.h>
 #endif
 
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#endif
 
 using namespace CMSat;
 
@@ -37,6 +43,35 @@ std::string irredDumpFname;
 
 using std::cout;
 using std::endl;
+
+#ifdef _WIN32
+static BOOL WINAPI CtrlHandler(DWORD fdwCtrlType)
+{
+    if (fdwCtrlType == CTRL_C_EVENT || fdwCtrlType == CTRL_BREAK_EVENT) {
+        std::cerr << "*** INTERRUPTED ***" << std::endl;
+        if (solverToInterrupt) {
+            // Set the atomic interrupt flag; the solver's search loop
+            // will detect this, abort cleanly, return l_Undef, and the
+            // normal exit path will print stats.
+            solverToInterrupt->interrupt_asap();
+        } else {
+            // No solver yet (e.g. still parsing); just exit.
+            exit(1);
+        }
+        return TRUE;  // signal handled, don't call next handler
+    }
+    return FALSE;  // pass to next handler (logoff, shutdown, etc.)
+}
+#endif
+
+void setup_signal_handler()
+{
+#ifdef _WIN32
+    SetConsoleCtrlHandler(CtrlHandler, TRUE);
+#else
+    signal(SIGINT, SIGINT_handler);
+#endif
+}
 
 void SIGINT_handler(int)
 {

--- a/src/signalcode.cpp
+++ b/src/signalcode.cpp
@@ -36,7 +36,7 @@ namespace CMSat {
 SATSolver* solverToInterrupt;
 int need_clean_exit;
 double wallclock_time_started = 0.0;
-bool g_python_lib = false;
+bool interrupt_only = false;
 std::string redDumpFname;
 std::string irredDumpFname;
 
@@ -46,13 +46,8 @@ void SIGINT_handler(int)
     cout << "c " << endl;
     std::cerr << "*** INTERRUPTED ***" << endl;
 
-    if (g_python_lib) {
-        // Library mode (Python): only set the interrupt flag, let the
-        // solver return l_Undef cleanly.  Do NOT call _exit() — that
-        // would kill the Python process.
-        if (solver) {
-            solver->interrupt_asap();
-        }
+    if (interrupt_only) {
+        if (solver) solver->interrupt_asap();
         return;
     }
 

--- a/src/signalcode.h
+++ b/src/signalcode.h
@@ -35,4 +35,9 @@ extern int need_clean_exit;
 extern double wallclock_time_started;
 void SIGINT_handler(int);
 
+// Platform-specific signal/interrupt setup.
+// On Windows this uses SetConsoleCtrlHandler (proper Ctrl+C handling).
+// On POSIX this uses signal(SIGINT, ...).
+void setup_signal_handler();
+
 #endif //SIGNALCODE_H_

--- a/src/signalcode.h
+++ b/src/signalcode.h
@@ -31,9 +31,7 @@ namespace CMSat {
     extern SATSolver* solverToInterrupt;
     extern int need_clean_exit;
     extern double wallclock_time_started;
-    // When true, SIGINT_handler only sets interrupt_asap() without _exit().
-    // Set by the Python module so the process stays alive after Ctrl+C.
-    extern bool g_python_lib;
+    extern bool interrupt_only;
     void SIGINT_handler(int);
 }
 

--- a/src/signalcode.h
+++ b/src/signalcode.h
@@ -33,11 +33,9 @@ using namespace CMSat;
 extern SATSolver* solverToInterrupt;
 extern int need_clean_exit;
 extern double wallclock_time_started;
+// When true, SIGINT_handler only sets interrupt_asap() without _exit().
+// Set by the Python module so the process stays alive after Ctrl+C.
+extern bool g_python_lib;
 void SIGINT_handler(int);
-
-// Platform-specific signal/interrupt setup.
-// On Windows this uses SetConsoleCtrlHandler (proper Ctrl+C handling).
-// On POSIX this uses signal(SIGINT, ...).
-void setup_signal_handler();
 
 #endif //SIGNALCODE_H_

--- a/src/signalcode.h
+++ b/src/signalcode.h
@@ -27,15 +27,14 @@ THE SOFTWARE.
 
 namespace CMSat {
     class SATSolver;
-}
-using namespace CMSat;
 
-extern SATSolver* solverToInterrupt;
-extern int need_clean_exit;
-extern double wallclock_time_started;
-// When true, SIGINT_handler only sets interrupt_asap() without _exit().
-// Set by the Python module so the process stays alive after Ctrl+C.
-extern bool g_python_lib;
-void SIGINT_handler(int);
+    extern SATSolver* solverToInterrupt;
+    extern int need_clean_exit;
+    extern double wallclock_time_started;
+    // When true, SIGINT_handler only sets interrupt_asap() without _exit().
+    // Set by the Python module so the process stays alive after Ctrl+C.
+    extern bool g_python_lib;
+    void SIGINT_handler(int);
+}
 
 #endif //SIGNALCODE_H_


### PR DESCRIPTION
I think this might be worth a discussion - maybe conditional compilation can placate or alleviate any concerns?  Because on Linux, I understand it is easier to kill processes but if someone is on Windows such as within VSCode, Ctrl+Z, Ctrl+D, etc is totally unresponsive.  So on Windows you have to literally open task manager and kill the process which is kind of unfortunate or a powershell process kill.

Also in Python, perhaps a script does multiple runs and Ctrl+C will have it give up one run and proceed onto the next one.  And Ctrl+C in the intervening period before the next run would cleanly kill the Python process as the handler falls back.

I would say the main justification though is that this is considered the standard de-facto behavior in most libraries.  So in general it is expected, though perhaps this is a special context where aborting is against intentions.  I generally like it during development, of course in production I understand your point, we could even add a flag when initializing the Python library to enable/disable such behavior too.  But I do think it is useful for development purposes especially.