### PR TITLE
Add windows python wheels

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         # Each runner builds for its native architecture.
         # Linux aarch64 uses a native ARM GitHub-hosted runner.
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-15-intel]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-15-intel, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -29,6 +29,29 @@ jobs:
         if: contains(matrix.os, 'macos')
         run: |
           brew install gmp || true
+
+      - name: Set up MSYS2 (Windows)
+        if: contains(matrix.os, 'windows')
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-ninja
+            mingw-w64-x86_64-gmp
+            mingw-w64-x86_64-zlib
+            mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-ccache
+
+      - name: Add MinGW to PATH (Windows)
+        if: contains(matrix.os, 'windows')
+        shell: bash
+        run: |
+          echo "C:/msys64/mingw64/bin" >> $GITHUB_PATH
+          echo "CC=gcc" >> $GITHUB_ENV
+          echo "CXX=g++" >> $GITHUB_ENV
 
       - name: Cache ccache
         uses: actions/cache@v4
@@ -49,6 +72,10 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: native   # x86_64 on ubuntu-latest, aarch64 on ubuntu-24.04-arm
           CIBW_ARCHS_MACOS: native   # arm64 on macos-14, x86_64 on macos-15-intel
+          CIBW_ARCHS_WINDOWS: native # AMD64 on windows-latest
+          CIBW_ENVIRONMENT_WINDOWS: |
+            CMAKE_GENERATOR=Ninja
+            PKG_CONFIG_PATH=C:/msys64/mingw64/lib/pkgconfig
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -84,13 +84,12 @@ jobs:
         uses: pypa/cibuildwheel@v3.1.0
         env:
           CIBW_ARCHS_WINDOWS: native
-          CIBW_ENVIRONMENT: |-
-            CC=gcc
-            CXX=g++
-            CMAKE_GENERATOR=Ninja
-            PKG_CONFIG_PATH=${{ env.MINGW_PREFIX }}/lib/pkgconfig
-            MSYS=winsymlinks:nativestrict
-            SKBUILD_CMAKE_ARGS=-DBUILD_PYTHON_EXTENSION=ON;-DENABLE_TESTING=OFF;-DBUILD_SHARED_LIBS=OFF;-DSTATIC_BINARY=OFF;-DCMAKE_POSITION_INDEPENDENT_CODE=ON;-DIPASIR=OFF
+          CC: gcc
+          CXX: g++
+          CMAKE_GENERATOR: Ninja
+          PKG_CONFIG_PATH: ${{ env.MINGW_PREFIX }}/lib/pkgconfig
+          MSYS: winsymlinks:nativestrict
+          SKBUILD_CMAKE_ARGS: -DBUILD_PYTHON_EXTENSION=ON;-DENABLE_TESTING=OFF;-DBUILD_SHARED_LIBS=OFF;-DSTATIC_BINARY=OFF;-DCMAKE_POSITION_INDEPENDENT_CODE=ON;-DIPASIR=OFF
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -91,7 +91,7 @@ jobs:
           export SKBUILD_CMAKE_ARGS="-DBUILD_PYTHON_EXTENSION=ON;-DENABLE_TESTING=OFF;-DBUILD_SHARED_LIBS=OFF;-DSTATIC_BINARY=OFF;-DCMAKE_POSITION_INDEPENDENT_CODE=ON;-DIPASIR=OFF"
           export CIBW_ARCHS_WINDOWS=native
           export CIBW_BUILD="cp39-* cp310-* cp311-* cp312-* cp313-*"
-          pip install cibuildwheel==3.1.0
+          pip install cibuildwheel==3.1.0 delvewheel
           python -m cibuildwheel --platform windows --output-dir wheelhouse .
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -60,19 +60,6 @@ jobs:
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
 
-      - name: Set cibuildwheel env (Windows)
-        if: contains(matrix.os, 'windows')
-        shell: bash
-        run: |
-          echo "CIBW_ENVIRONMENT<<CIBWEOF" >> $GITHUB_ENV
-          echo "CC=gcc" >> $GITHUB_ENV
-          echo "CXX=g++" >> $GITHUB_ENV
-          echo "CMAKE_GENERATOR=Ninja" >> $GITHUB_ENV
-          echo "PKG_CONFIG_PATH=${{ env.MINGW_PREFIX }}/lib/pkgconfig" >> $GITHUB_ENV
-          echo "MSYS=winsymlinks:nativestrict" >> $GITHUB_ENV
-          echo "SKBUILD_CMAKE_ARGS=-DBUILD_PYTHON_EXTENSION=ON;-DENABLE_TESTING=OFF;-DBUILD_SHARED_LIBS=OFF;-DSTATIC_BINARY=OFF;-DCMAKE_POSITION_INDEPENDENT_CODE=ON;-DIPASIR=OFF" >> $GITHUB_ENV
-          echo "CIBWEOF" >> $GITHUB_ENV
-
       - name: Cache ccache
         uses: actions/cache@v4
         with:
@@ -85,14 +72,25 @@ jobs:
           key: ccache-${{ matrix.os }}-${{ github.sha }}
           restore-keys: ccache-${{ matrix.os }}-
 
-      - name: Build wheels
+      - name: Build wheels (not Windows)
+        if: "!contains(matrix.os, 'windows')"
         uses: pypa/cibuildwheel@v3.1.0
-        # All cibuildwheel settings live in [tool.cibuildwheel] in pyproject.toml.
-        # The only per-runner override needed is the arch selector:
         env:
-          CIBW_ARCHS_LINUX: native   # x86_64 on ubuntu-latest, aarch64 on ubuntu-24.04-arm
-          CIBW_ARCHS_MACOS: native   # arm64 on macos-14, x86_64 on macos-15-intel
-          CIBW_ARCHS_WINDOWS: native # AMD64 on windows-latest
+          CIBW_ARCHS_LINUX: native
+          CIBW_ARCHS_MACOS: native
+
+      - name: Build wheels (Windows)
+        if: contains(matrix.os, 'windows')
+        uses: pypa/cibuildwheel@v3.1.0
+        env:
+          CIBW_ARCHS_WINDOWS: native
+          CIBW_ENVIRONMENT: |-
+            CC=gcc
+            CXX=g++
+            CMAKE_GENERATOR=Ninja
+            PKG_CONFIG_PATH=${{ env.MINGW_PREFIX }}/lib/pkgconfig
+            MSYS=winsymlinks:nativestrict
+            SKBUILD_CMAKE_ARGS=-DBUILD_PYTHON_EXTENSION=ON;-DENABLE_TESTING=OFF;-DBUILD_SHARED_LIBS=OFF;-DSTATIC_BINARY=OFF;-DCMAKE_POSITION_INDEPENDENT_CODE=ON;-DIPASIR=OFF
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Add MinGW to PATH (Windows)
         if: contains(matrix.os, 'windows')
+        shell: bash
         run: |
           echo "${{ env.MINGW_BIN }}" >> $GITHUB_PATH
           echo "CC=gcc" >> $GITHUB_ENV
@@ -61,8 +62,11 @@ jobs:
 
       - name: Set cibuildwheel env (Windows)
         if: contains(matrix.os, 'windows')
+        shell: bash
         run: |
           echo "CIBW_ENVIRONMENT<<CIBWEOF" >> $GITHUB_ENV
+          echo "CC=gcc" >> $GITHUB_ENV
+          echo "CXX=g++" >> $GITHUB_ENV
           echo "CMAKE_GENERATOR=Ninja" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=${{ env.MINGW_PREFIX }}/lib/pkgconfig" >> $GITHUB_ENV
           echo "MSYS=winsymlinks:nativestrict" >> $GITHUB_ENV

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -42,14 +42,20 @@ jobs:
             mingw-w64-x86_64-ninja
             mingw-w64-x86_64-gmp
             mingw-w64-x86_64-zlib
-            mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-pkgconf
             mingw-w64-x86_64-ccache
+
+      - name: Get MSYS2 MinGW prefix (Windows)
+        if: contains(matrix.os, 'windows')
+        shell: msys2 {0}
+        run: |
+          echo "MINGW_PREFIX=$(cygpath -m /mingw64)" >> $GITHUB_ENV
+          echo "MINGW_BIN=$(cygpath -m /mingw64)/bin" >> $GITHUB_ENV
 
       - name: Add MinGW to PATH (Windows)
         if: contains(matrix.os, 'windows')
-        shell: bash
         run: |
-          echo "C:/msys64/mingw64/bin" >> $GITHUB_PATH
+          echo "${{ env.MINGW_BIN }}" >> $GITHUB_PATH
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
 
@@ -75,7 +81,7 @@ jobs:
           CIBW_ARCHS_WINDOWS: native # AMD64 on windows-latest
           CIBW_ENVIRONMENT_WINDOWS: |
             CMAKE_GENERATOR=Ninja
-            PKG_CONFIG_PATH=C:/msys64/mingw64/lib/pkgconfig
+            PKG_CONFIG_PATH=${{ env.MINGW_PREFIX }}/lib/pkgconfig
             MSYS=winsymlinks:nativestrict
             SKBUILD_CMAKE_ARGS=-DBUILD_PYTHON_EXTENSION=ON;-DENABLE_TESTING=OFF;-DBUILD_SHARED_LIBS=OFF;-DSTATIC_BINARY=OFF;-DCMAKE_POSITION_INDEPENDENT_CODE=ON;-DIPASIR=OFF
 

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -2,7 +2,7 @@ name: Build and publish Python wheels
 
 on:
   push:
-    branches: ["master", "add-windows-python-wheels", "add-python-ctrl-c"]
+    branches: ["master"]
     tags:
       - 'release/v[0-9]+.[0-9]+.[0-9]+'
   pull_request:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -2,7 +2,7 @@ name: Build and publish Python wheels
 
 on:
   push:
-    branches: ["master"]
+    branches: ["master", "add-windows-python-wheels", "add-python-ctrl-c"]
     tags:
       - 'release/v[0-9]+.[0-9]+.[0-9]+'
   pull_request:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -80,6 +80,7 @@ jobs:
           CIBW_ARCHS_MACOS: native   # arm64 on macos-14, x86_64 on macos-15-intel
           CIBW_ARCHS_WINDOWS: native # AMD64 on windows-latest
           CIBW_ENVIRONMENT_WINDOWS: |
+            PATH=${{ env.MINGW_BIN }};$PATH
             CMAKE_GENERATOR=Ninja
             PKG_CONFIG_PATH=${{ env.MINGW_PREFIX }}/lib/pkgconfig
             MSYS=winsymlinks:nativestrict

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -76,6 +76,8 @@ jobs:
           CIBW_ENVIRONMENT_WINDOWS: |
             CMAKE_GENERATOR=Ninja
             PKG_CONFIG_PATH=C:/msys64/mingw64/lib/pkgconfig
+            MSYS=winsymlinks:nativestrict
+            SKBUILD_CMAKE_ARGS=-DBUILD_PYTHON_EXTENSION=ON;-DENABLE_TESTING=OFF;-DBUILD_SHARED_LIBS=OFF;-DSTATIC_BINARY=OFF;-DCMAKE_POSITION_INDEPENDENT_CODE=ON;-DIPASIR=OFF
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -84,12 +84,7 @@ jobs:
         uses: pypa/cibuildwheel@v3.1.0
         env:
           CIBW_ARCHS_WINDOWS: native
-          CC: gcc
-          CXX: g++
-          CMAKE_GENERATOR: Ninja
-          PKG_CONFIG_PATH: ${{ env.MINGW_PREFIX }}/lib/pkgconfig
-          MSYS: winsymlinks:nativestrict
-          SKBUILD_CMAKE_ARGS: -DBUILD_PYTHON_EXTENSION=ON;-DENABLE_TESTING=OFF;-DBUILD_SHARED_LIBS=OFF;-DSTATIC_BINARY=OFF;-DCMAKE_POSITION_INDEPENDENT_CODE=ON;-DIPASIR=OFF
+          CIBW_ENVIRONMENT: "CC=gcc\nCXX=g++\nCMAKE_GENERATOR=Ninja\nPKG_CONFIG_PATH=${{ env.MINGW_PREFIX }}/lib/pkgconfig\nMSYS=winsymlinks:nativestrict\nSKBUILD_CMAKE_ARGS=-DBUILD_PYTHON_EXTENSION=ON;-DENABLE_TESTING=OFF;-DBUILD_SHARED_LIBS=OFF;-DSTATIC_BINARY=OFF;-DCMAKE_POSITION_INDEPENDENT_CODE=ON;-DIPASIR=OFF"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -99,6 +99,25 @@ jobs:
           name: wheels-${{ matrix.os }}
           path: wheelhouse/*.whl
 
+  publish-test:
+    name: Test publish (dry-run)
+    needs: build_wheels
+    runs-on: ubuntu-latest
+    # Run on every push/PR so non-maintainers can verify publish would succeed.
+    if: "! (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/release/v'))"
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+
+      - name: Validate wheels with twine
+        run: |
+          pip install twine
+          twine check dist/*.whl
+
   publish:
     name: Publish to PyPI
     needs: build_wheels

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -59,6 +59,16 @@ jobs:
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
 
+      - name: Set cibuildwheel env (Windows)
+        if: contains(matrix.os, 'windows')
+        run: |
+          echo "CIBW_ENVIRONMENT<<CIBWEOF" >> $GITHUB_ENV
+          echo "CMAKE_GENERATOR=Ninja" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=${{ env.MINGW_PREFIX }}/lib/pkgconfig" >> $GITHUB_ENV
+          echo "MSYS=winsymlinks:nativestrict" >> $GITHUB_ENV
+          echo "SKBUILD_CMAKE_ARGS=-DBUILD_PYTHON_EXTENSION=ON;-DENABLE_TESTING=OFF;-DBUILD_SHARED_LIBS=OFF;-DSTATIC_BINARY=OFF;-DCMAKE_POSITION_INDEPENDENT_CODE=ON;-DIPASIR=OFF" >> $GITHUB_ENV
+          echo "CIBWEOF" >> $GITHUB_ENV
+
       - name: Cache ccache
         uses: actions/cache@v4
         with:
@@ -79,12 +89,6 @@ jobs:
           CIBW_ARCHS_LINUX: native   # x86_64 on ubuntu-latest, aarch64 on ubuntu-24.04-arm
           CIBW_ARCHS_MACOS: native   # arm64 on macos-14, x86_64 on macos-15-intel
           CIBW_ARCHS_WINDOWS: native # AMD64 on windows-latest
-          CIBW_ENVIRONMENT_WINDOWS: |
-            PATH=${{ env.MINGW_BIN }};$PATH
-            CMAKE_GENERATOR=Ninja
-            PKG_CONFIG_PATH=${{ env.MINGW_PREFIX }}/lib/pkgconfig
-            MSYS=winsymlinks:nativestrict
-            SKBUILD_CMAKE_ARGS=-DBUILD_PYTHON_EXTENSION=ON;-DENABLE_TESTING=OFF;-DBUILD_SHARED_LIBS=OFF;-DSTATIC_BINARY=OFF;-DCMAKE_POSITION_INDEPENDENT_CODE=ON;-DIPASIR=OFF
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -81,10 +81,18 @@ jobs:
 
       - name: Build wheels (Windows)
         if: contains(matrix.os, 'windows')
-        uses: pypa/cibuildwheel@v3.1.0
-        env:
-          CIBW_ARCHS_WINDOWS: native
-          CIBW_ENVIRONMENT: "CC=gcc\nCXX=g++\nCMAKE_GENERATOR=Ninja\nPKG_CONFIG_PATH=${{ env.MINGW_PREFIX }}/lib/pkgconfig\nMSYS=winsymlinks:nativestrict\nSKBUILD_CMAKE_ARGS=-DBUILD_PYTHON_EXTENSION=ON;-DENABLE_TESTING=OFF;-DBUILD_SHARED_LIBS=OFF;-DSTATIC_BINARY=OFF;-DCMAKE_POSITION_INDEPENDENT_CODE=ON;-DIPASIR=OFF"
+        shell: bash
+        run: |
+          export CC=gcc
+          export CXX=g++
+          export CMAKE_GENERATOR=Ninja
+          export PKG_CONFIG_PATH="${{ env.MINGW_PREFIX }}/lib/pkgconfig"
+          export MSYS=winsymlinks:nativestrict
+          export SKBUILD_CMAKE_ARGS="-DBUILD_PYTHON_EXTENSION=ON;-DENABLE_TESTING=OFF;-DBUILD_SHARED_LIBS=OFF;-DSTATIC_BINARY=OFF;-DCMAKE_POSITION_INDEPENDENT_CODE=ON;-DIPASIR=OFF"
+          export CIBW_ARCHS_WINDOWS=native
+          export CIBW_BUILD="cp39-* cp310-* cp311-* cp312-* cp313-*"
+          pip install cibuildwheel==3.1.0
+          python -m cibuildwheel --platform windows --output-dir wheelhouse .
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -2,7 +2,7 @@ name: Build and publish Python wheels
 
 on:
   push:
-    branches: ["master"]
+    branches: ["master", "add-windows-python-wheels"]
     tags:
       - 'release/v[0-9]+.[0-9]+.[0-9]+'
   pull_request:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -681,8 +681,11 @@ if(BUILD_PYTHON_EXTENSION)
 
     target_compile_definitions(pycryptosat PRIVATE
         CMS_FULL_VERSION="${CMS_FULL_VERSION}")
+    # MinGW can't use MSVC .lib to resolve __imp_ stubs.  Undefine
+    # dllimport from Python API macros but keep dllexport for PyInit_.
     target_compile_options(pycryptosat PRIVATE
-        "-D__declspec(x)=")  # prevent __imp_ stubs (MinGW vs MSVC DLLs)
+        "-DPyAPI_FUNC(RTYPE)=RTYPE"
+        "-DPyAPI_DATA(RTYPE)=extern RTYPE")
     target_compile_features(pycryptosat PRIVATE cxx_std_17)
     install(TARGETS pycryptosat DESTINATION . COMPONENT python)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -656,6 +656,9 @@ if(BUILD_PYTHON_EXTENSION)
         set(Python_INCLUDE_DIRS "${_py_base}/include")
         # MinGW can link directly against the DLL.
         set(Python_LIBRARIES "${_py_base}/python3.dll")
+        # Must call find_package with Development (even if non-required)
+        # to make python_add_library available.
+        find_package(Python COMPONENTS Development)
     else()
         find_package(Python REQUIRED COMPONENTS Development.Module)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -651,29 +651,19 @@ if(BUILD_PYTHON_EXTENSION)
             "import sys; print(sys.base_prefix)"
             OUTPUT_VARIABLE _py_base OUTPUT_STRIP_TRAILING_WHITESPACE)
 
+        # Create an IMPORTED target for python3.dll so CMake handles
+        # the linking correctly (resolves __imp_ stubs for MinGW).
+        add_library(python3_shared SHARED IMPORTED)
+        set_target_properties(python3_shared PROPERTIES
+            IMPORTED_LOCATION "${_py_base}/python3.dll"
+            IMPORTED_IMPLIB   "${_py_base}/libs/python3.lib")
+
         add_library(pycryptosat MODULE python/src/pycryptosat.cpp)
         target_include_directories(pycryptosat PRIVATE
             "${_py_base}/include"
             ${PROJECT_SOURCE_DIR}/src
             ${PROJECT_SOURCE_DIR})
-
-        # Generate MinGW import library from the MSVC-compiled python3.dll.
-        # gendef extracts symbols, dlltool creates the .a that MinGW's ld needs.
-        set(_py_implib "${CMAKE_CURRENT_BINARY_DIR}/libpython3.a")
-        execute_process(COMMAND gendef - "${_py_base}/python3.dll"
-            OUTPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/python3.def"
-            RESULT_VARIABLE _gendef_rc)
-        if(_gendef_rc EQUAL 0)
-            execute_process(COMMAND dlltool -m i386:x86-64
-                -d "${CMAKE_CURRENT_BINARY_DIR}/python3.def"
-                -l "${_py_implib}" -D "${_py_base}/python3.dll"
-                RESULT_VARIABLE _dlltool_rc)
-        endif()
-        if(_gendef_rc EQUAL 0 AND _dlltool_rc EQUAL 0)
-            target_link_libraries(pycryptosat PRIVATE cryptominisat5 "${_py_implib}")
-        else()
-            target_link_libraries(pycryptosat PRIVATE cryptominisat5 "${_py_base}/libs/python3.lib")
-        endif()
+        target_link_libraries(pycryptosat PRIVATE cryptominisat5 python3_shared)
         set_target_properties(pycryptosat PROPERTIES PREFIX "" SUFFIX ".pyd")
     else()
         find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -645,20 +645,17 @@ add_subdirectory(src cmsat5-src)
 # =============================================================================
 option(BUILD_PYTHON_EXTENSION "Build the pycryptosat Python extension module" OFF)
 if(BUILD_PYTHON_EXTENSION)
+    # On Windows NuGet/portable Python, sysconfig may not report LIBDIR
+    # so find_package(Python Development) fails.  Set paths manually
+    # and include FindPython/Support directly for python_add_library.
     find_package(Python REQUIRED COMPONENTS Interpreter)
     if(WIN32)
-        # NuGet/portable Python on Windows may not expose dev libraries
-        # via sysconfig (no libs/python3.lib).  Build include/lib paths
-        # manually from the interpreter's base prefix.
         execute_process(COMMAND "${Python_EXECUTABLE}" -c
             "import sys; print(sys.base_prefix)"
             OUTPUT_VARIABLE _py_base OUTPUT_STRIP_TRAILING_WHITESPACE)
         set(Python_INCLUDE_DIRS "${_py_base}/include")
-        # MinGW can link directly against the DLL.
         set(Python_LIBRARIES "${_py_base}/python3.dll")
-        # Must call find_package with Development (even if non-required)
-        # to make python_add_library available.
-        find_package(Python COMPONENTS Development)
+        include("${CMAKE_ROOT}/Modules/FindPython/Support.cmake")
     else()
         find_package(Python REQUIRED COMPONENTS Development.Module)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -651,33 +651,17 @@ if(BUILD_PYTHON_EXTENSION)
             "import sys; print(sys.base_prefix)"
             OUTPUT_VARIABLE _py_base OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-        # Create an IMPORTED target for python3.dll so CMake handles
-        # the linking correctly (resolves __imp_ stubs for MinGW).
-        add_library(python3_shared SHARED IMPORTED)
-        set_property(TARGET python3_shared PROPERTY IMPORTED_LOCATION "${_py_base}/python3.dll")
-        if(EXISTS "${_py_base}/libs/python3.lib")
-            set_property(TARGET python3_shared PROPERTY IMPORTED_IMPLIB "${_py_base}/libs/python3.lib")
-        else()
-            # NuGet Python may lack python3.lib. Generate one with dlltool.
-            set(_py_implib "${CMAKE_CURRENT_BINARY_DIR}/libpython3.a")
-            execute_process(COMMAND gendef - "${_py_base}/python3.dll"
-                OUTPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/python3.def"
-                RESULT_VARIABLE _rc)
-            if(_rc EQUAL 0)
-                execute_process(COMMAND dlltool -m i386:x86-64
-                    -d "${CMAKE_CURRENT_BINARY_DIR}/python3.def"
-                    -l "${_py_implib}" -D "${_py_base}/python3.dll")
-            endif()
-            set_property(TARGET python3_shared PROPERTY IMPORTED_IMPLIB "${_py_implib}")
-        endif()
-
         add_library(pycryptosat MODULE python/src/pycryptosat.cpp)
         target_include_directories(pycryptosat PRIVATE
             "${_py_base}/include"
             ${PROJECT_SOURCE_DIR}/src
             ${PROJECT_SOURCE_DIR})
-        target_link_libraries(pycryptosat PRIVATE cryptominisat5 python3_shared)
-        target_link_options(pycryptosat PRIVATE "-Wl,--enable-auto-import")
+        target_link_libraries(pycryptosat PRIVATE cryptominisat5)
+        # MinGW can't use MSVC .lib; let __imp_ symbols resolve at runtime
+        # from the already-loaded python3.dll.
+        target_link_options(pycryptosat PRIVATE
+            "SHELL:-Wl,--enable-auto-import"
+            "SHELL:-Wl,--unresolved-symbols=ignore-in-shared-libs")
         set_target_properties(pycryptosat PROPERTIES PREFIX "" SUFFIX ".pyd")
     else()
         find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -663,6 +663,7 @@ if(BUILD_PYTHON_EXTENSION)
             ${PROJECT_SOURCE_DIR}/src
             ${PROJECT_SOURCE_DIR})
         target_link_libraries(pycryptosat PRIVATE cryptominisat5 python3_shared)
+        target_link_options(pycryptosat PRIVATE "-Wl,--enable-auto-import")
         set_target_properties(pycryptosat PROPERTIES PREFIX "" SUFFIX ".pyd")
     else()
         find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -645,17 +645,16 @@ add_subdirectory(src cmsat5-src)
 # =============================================================================
 option(BUILD_PYTHON_EXTENSION "Build the pycryptosat Python extension module" OFF)
 if(BUILD_PYTHON_EXTENSION)
-    find_package(Python REQUIRED COMPONENTS Interpreter)
     # On Windows NuGet/portable Python, sysconfig may not report LIBDIR.
-    # Set Python_ROOT_DIR from sys.base_prefix to help FindPython locate
-    # the development libraries (python3.lib, headers).
-    if(WIN32)
+    # Compute Python_ROOT_DIR from sys.base_prefix before calling
+    # find_package so CMake can locate python3.lib and headers.
+    if(WIN32 AND Python_EXECUTABLE)
         execute_process(COMMAND "${Python_EXECUTABLE}" -c
             "import sys; print(sys.base_prefix)"
             OUTPUT_VARIABLE _py_base OUTPUT_STRIP_TRAILING_WHITESPACE)
         set(Python_ROOT_DIR "${_py_base}")
     endif()
-    find_package(Python REQUIRED COMPONENTS Development.Module)
+    find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
 
     # pycryptosat.cpp uses only the raw Python C API; GitSHA1 symbols are
     # already provided by the cryptominisat5 static library.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -645,7 +645,17 @@ add_subdirectory(src cmsat5-src)
 # =============================================================================
 option(BUILD_PYTHON_EXTENSION "Build the pycryptosat Python extension module" OFF)
 if(BUILD_PYTHON_EXTENSION)
-    find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
+    find_package(Python REQUIRED COMPONENTS Interpreter)
+    # On Windows NuGet/portable Python, sysconfig may not report LIBDIR.
+    # Set Python_ROOT_DIR from sys.base_prefix to help FindPython locate
+    # the development libraries (python3.lib, headers).
+    if(WIN32)
+        execute_process(COMMAND "${Python_EXECUTABLE}" -c
+            "import sys; print(sys.base_prefix)"
+            OUTPUT_VARIABLE _py_base OUTPUT_STRIP_TRAILING_WHITESPACE)
+        set(Python_ROOT_DIR "${_py_base}")
+    endif()
+    find_package(Python REQUIRED COMPONENTS Development.Module)
 
     # pycryptosat.cpp uses only the raw Python C API; GitSHA1 symbols are
     # already provided by the cryptominisat5 static library.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -655,8 +655,7 @@ if(BUILD_PYTHON_EXTENSION)
         # the linking correctly (resolves __imp_ stubs for MinGW).
         add_library(python3_shared SHARED IMPORTED)
         set_target_properties(python3_shared PROPERTIES
-            IMPORTED_LOCATION "${_py_base}/python3.dll"
-            IMPORTED_IMPLIB   "${_py_base}/libs/python3.lib")
+            IMPORTED_LOCATION "${_py_base}/python3.dll")
 
         add_library(pycryptosat MODULE python/src/pycryptosat.cpp)
         target_include_directories(pycryptosat PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -641,44 +641,37 @@ add_subdirectory(src cmsat5-src)
 # =============================================================================
 # Python extension module (pycryptosat)
 # Activated by scikit-build-core via -DBUILD_PYTHON_EXTENSION=ON.
-# Requires CMake >= 3.18 (python_add_library).
 # =============================================================================
 option(BUILD_PYTHON_EXTENSION "Build the pycryptosat Python extension module" OFF)
 if(BUILD_PYTHON_EXTENSION)
-    # On Windows NuGet/portable Python, sysconfig may not report LIBDIR
-    # so find_package(Python Development) fails.  Set paths manually
-    # and include FindPython/Support directly for python_add_library.
-    find_package(Python REQUIRED COMPONENTS Interpreter)
     if(WIN32)
+        # NuGet Python lacks dev libraries; build manually with add_library.
+        find_package(Python REQUIRED COMPONENTS Interpreter)
         execute_process(COMMAND "${Python_EXECUTABLE}" -c
             "import sys; print(sys.base_prefix)"
             OUTPUT_VARIABLE _py_base OUTPUT_STRIP_TRAILING_WHITESPACE)
-        set(Python_INCLUDE_DIRS "${_py_base}/include")
-        set(Python_LIBRARIES "${_py_base}/python3.dll")
-        include("${CMAKE_ROOT}/Modules/FindPython/Support.cmake")
+
+        add_library(pycryptosat MODULE python/src/pycryptosat.cpp)
+        target_include_directories(pycryptosat PRIVATE
+            "${_py_base}/include"
+            ${PROJECT_SOURCE_DIR}/src
+            ${PROJECT_SOURCE_DIR})
+        target_link_libraries(pycryptosat PRIVATE
+            cryptominisat5 "${_py_base}/python3.dll")
+        set_target_properties(pycryptosat PROPERTIES PREFIX "" SUFFIX ".pyd")
     else()
-        find_package(Python REQUIRED COMPONENTS Development.Module)
+        find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
+        python_add_library(pycryptosat MODULE WITH_SOABI
+            python/src/pycryptosat.cpp)
+        target_include_directories(pycryptosat PRIVATE
+            ${PROJECT_SOURCE_DIR}/src
+            ${PROJECT_SOURCE_DIR})
+        target_link_libraries(pycryptosat PRIVATE cryptominisat5)
     endif()
 
-    # pycryptosat.cpp uses only the raw Python C API; GitSHA1 symbols are
-    # already provided by the cryptominisat5 static library.
-    python_add_library(pycryptosat MODULE WITH_SOABI
-        python/src/pycryptosat.cpp
-    )
-
     target_compile_definitions(pycryptosat PRIVATE
-        CMS_FULL_VERSION="${CMS_FULL_VERSION}"
-    )
-
-    target_include_directories(pycryptosat PRIVATE
-        ${PROJECT_SOURCE_DIR}/src
-        ${PROJECT_SOURCE_DIR}
-    )
-
-    target_link_libraries(pycryptosat PRIVATE cryptominisat5)
+        CMS_FULL_VERSION="${CMS_FULL_VERSION}")
     target_compile_features(pycryptosat PRIVATE cxx_std_17)
-
-    # Only install the extension into the wheel (not the static lib / headers / binary).
     install(TARGETS pycryptosat DESTINATION . COMPONENT python)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -645,16 +645,20 @@ add_subdirectory(src cmsat5-src)
 # =============================================================================
 option(BUILD_PYTHON_EXTENSION "Build the pycryptosat Python extension module" OFF)
 if(BUILD_PYTHON_EXTENSION)
-    # On Windows NuGet/portable Python, sysconfig may not report LIBDIR.
-    # Compute Python_ROOT_DIR from sys.base_prefix before calling
-    # find_package so CMake can locate python3.lib and headers.
-    if(WIN32 AND Python_EXECUTABLE)
+    find_package(Python REQUIRED COMPONENTS Interpreter)
+    if(WIN32)
+        # NuGet/portable Python on Windows may not expose dev libraries
+        # via sysconfig (no libs/python3.lib).  Build include/lib paths
+        # manually from the interpreter's base prefix.
         execute_process(COMMAND "${Python_EXECUTABLE}" -c
             "import sys; print(sys.base_prefix)"
             OUTPUT_VARIABLE _py_base OUTPUT_STRIP_TRAILING_WHITESPACE)
-        set(Python_ROOT_DIR "${_py_base}")
+        set(Python_INCLUDE_DIRS "${_py_base}/include")
+        # MinGW can link directly against the DLL.
+        set(Python_LIBRARIES "${_py_base}/python3.dll")
+    else()
+        find_package(Python REQUIRED COMPONENTS Development.Module)
     endif()
-    find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
 
     # pycryptosat.cpp uses only the raw Python C API; GitSHA1 symbols are
     # already provided by the cryptominisat5 static library.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -656,12 +656,9 @@ if(BUILD_PYTHON_EXTENSION)
             "${_py_base}/include"
             ${PROJECT_SOURCE_DIR}/src
             ${PROJECT_SOURCE_DIR})
-        target_link_libraries(pycryptosat PRIVATE cryptominisat5)
-        # MinGW can't use MSVC .lib; let __imp_ symbols resolve at runtime
-        # from the already-loaded python3.dll.
+        target_link_libraries(pycryptosat PRIVATE cryptominisat5 "${_py_base}/python3.dll")
         target_link_options(pycryptosat PRIVATE
-            "SHELL:-Wl,--enable-auto-import"
-            "SHELL:-Wl,--unresolved-symbols=ignore-in-shared-libs")
+            "SHELL:-Wl,--enable-auto-import")
         set_target_properties(pycryptosat PROPERTIES PREFIX "" SUFFIX ".pyd")
     else()
         find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -672,6 +672,8 @@ if(BUILD_PYTHON_EXTENSION)
 
     target_compile_definitions(pycryptosat PRIVATE
         CMS_FULL_VERSION="${CMS_FULL_VERSION}")
+    target_compile_options(pycryptosat PRIVATE
+        "-D__declspec(x)=")  # prevent __imp_ stubs (MinGW vs MSVC DLLs)
     target_compile_features(pycryptosat PRIVATE cxx_std_17)
     install(TARGETS pycryptosat DESTINATION . COMPONENT python)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -654,8 +654,22 @@ if(BUILD_PYTHON_EXTENSION)
         # Create an IMPORTED target for python3.dll so CMake handles
         # the linking correctly (resolves __imp_ stubs for MinGW).
         add_library(python3_shared SHARED IMPORTED)
-        set_target_properties(python3_shared PROPERTIES
-            IMPORTED_LOCATION "${_py_base}/python3.dll")
+        set_property(TARGET python3_shared PROPERTY IMPORTED_LOCATION "${_py_base}/python3.dll")
+        if(EXISTS "${_py_base}/libs/python3.lib")
+            set_property(TARGET python3_shared PROPERTY IMPORTED_IMPLIB "${_py_base}/libs/python3.lib")
+        else()
+            # NuGet Python may lack python3.lib. Generate one with dlltool.
+            set(_py_implib "${CMAKE_CURRENT_BINARY_DIR}/libpython3.a")
+            execute_process(COMMAND gendef - "${_py_base}/python3.dll"
+                OUTPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/python3.def"
+                RESULT_VARIABLE _rc)
+            if(_rc EQUAL 0)
+                execute_process(COMMAND dlltool -m i386:x86-64
+                    -d "${CMAKE_CURRENT_BINARY_DIR}/python3.def"
+                    -l "${_py_implib}" -D "${_py_base}/python3.dll")
+            endif()
+            set_property(TARGET python3_shared PROPERTY IMPORTED_IMPLIB "${_py_implib}")
+        endif()
 
         add_library(pycryptosat MODULE python/src/pycryptosat.cpp)
         target_include_directories(pycryptosat PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -648,15 +648,24 @@ if(BUILD_PYTHON_EXTENSION)
         # NuGet Python lacks dev libraries; build manually with add_library.
         find_package(Python REQUIRED COMPONENTS Interpreter)
         execute_process(COMMAND "${Python_EXECUTABLE}" -c
-            "import sys; print(sys.base_prefix)"
-            OUTPUT_VARIABLE _py_base OUTPUT_STRIP_TRAILING_WHITESPACE)
+            "import sys; print(sys.base_prefix); print(f'{sys.version_info.major}{sys.version_info.minor}')"
+            OUTPUT_VARIABLE _py_info OUTPUT_STRIP_TRAILING_WHITESPACE)
+        string(REGEX REPLACE "\n" ";" _py_info "${_py_info}")
+        list(GET _py_info 0 _py_base)
+        list(GET _py_info 1 _py_ver)
+        # python3.dll (stable ABI) only exports buffer protocol from 3.11+.
+        # Use the versioned DLL for full API coverage.
+        set(_py_dll "${_py_base}/python${_py_ver}.dll")
+        if(NOT EXISTS "${_py_dll}")
+            set(_py_dll "${_py_base}/python3.dll")
+        endif()
 
         add_library(pycryptosat MODULE python/src/pycryptosat.cpp)
         target_include_directories(pycryptosat PRIVATE
             "${_py_base}/include"
             ${PROJECT_SOURCE_DIR}/src
             ${PROJECT_SOURCE_DIR})
-        target_link_libraries(pycryptosat PRIVATE cryptominisat5 "${_py_base}/python3.dll")
+        target_link_libraries(pycryptosat PRIVATE cryptominisat5 "${_py_dll}")
         target_link_options(pycryptosat PRIVATE
             "SHELL:-Wl,--enable-auto-import")
         set_target_properties(pycryptosat PROPERTIES PREFIX "" SUFFIX ".pyd")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -664,14 +664,15 @@ if(BUILD_PYTHON_EXTENSION)
             OUTPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/python3.def"
             RESULT_VARIABLE _gendef_rc)
         if(_gendef_rc EQUAL 0)
-            execute_process(COMMAND dlltool -d "${CMAKE_CURRENT_BINARY_DIR}/python3.def"
+            execute_process(COMMAND dlltool -m i386:x86-64
+                -d "${CMAKE_CURRENT_BINARY_DIR}/python3.def"
                 -l "${_py_implib}" -D "${_py_base}/python3.dll"
                 RESULT_VARIABLE _dlltool_rc)
         endif()
         if(_gendef_rc EQUAL 0 AND _dlltool_rc EQUAL 0)
             target_link_libraries(pycryptosat PRIVATE cryptominisat5 "${_py_implib}")
         else()
-            target_link_libraries(pycryptosat PRIVATE cryptominisat5 "${_py_base}/python3.dll")
+            target_link_libraries(pycryptosat PRIVATE cryptominisat5 "${_py_base}/libs/python3.lib")
         endif()
         set_target_properties(pycryptosat PROPERTIES PREFIX "" SUFFIX ".pyd")
     else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -665,9 +665,24 @@ if(BUILD_PYTHON_EXTENSION)
             "${_py_base}/include"
             ${PROJECT_SOURCE_DIR}/src
             ${PROJECT_SOURCE_DIR})
-        target_link_libraries(pycryptosat PRIVATE cryptominisat5 "${_py_dll}")
-        target_link_options(pycryptosat PRIVATE
-            "SHELL:-Wl,--enable-auto-import")
+        # Create a proper import library for the Python DLL to avoid
+        # --enable-auto-import which can pull symbols from unrelated
+        # DLLs on PATH at runtime (causing debug/release mixing crashes).
+        get_filename_component(_py_dll_name "${_py_dll}" NAME_WE)
+        set(_py_def "${CMAKE_CURRENT_BINARY_DIR}/${_py_dll_name}.def")
+        set(_py_implib "${CMAKE_CURRENT_BINARY_DIR}/lib${_py_dll_name}.dll.a")
+        add_custom_command(OUTPUT "${_py_def}"
+            COMMAND gendef "${_py_dll}"
+            WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+            DEPENDS "${_py_dll}"
+            COMMENT "Generating .def from ${_py_dll}")
+        add_custom_command(OUTPUT "${_py_implib}"
+            COMMAND dlltool -d "${_py_def}" -l "${_py_implib}" -D "${_py_dll}"
+            DEPENDS "${_py_def}"
+            COMMENT "Creating import library for ${_py_dll}")
+        add_custom_target(_py_implib_target DEPENDS "${_py_implib}")
+        add_dependencies(pycryptosat _py_implib_target)
+        target_link_libraries(pycryptosat PRIVATE cryptominisat5 "${_py_implib}")
         set_target_properties(pycryptosat PROPERTIES PREFIX "" SUFFIX ".pyd")
     else()
         find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -656,8 +656,23 @@ if(BUILD_PYTHON_EXTENSION)
             "${_py_base}/include"
             ${PROJECT_SOURCE_DIR}/src
             ${PROJECT_SOURCE_DIR})
-        target_link_libraries(pycryptosat PRIVATE
-            cryptominisat5 "${_py_base}/python3.dll")
+
+        # Generate MinGW import library from the MSVC-compiled python3.dll.
+        # gendef extracts symbols, dlltool creates the .a that MinGW's ld needs.
+        set(_py_implib "${CMAKE_CURRENT_BINARY_DIR}/libpython3.a")
+        execute_process(COMMAND gendef - "${_py_base}/python3.dll"
+            OUTPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/python3.def"
+            RESULT_VARIABLE _gendef_rc)
+        if(_gendef_rc EQUAL 0)
+            execute_process(COMMAND dlltool -d "${CMAKE_CURRENT_BINARY_DIR}/python3.def"
+                -l "${_py_implib}" -D "${_py_base}/python3.dll"
+                RESULT_VARIABLE _dlltool_rc)
+        endif()
+        if(_gendef_rc EQUAL 0 AND _dlltool_rc EQUAL 0)
+            target_link_libraries(pycryptosat PRIVATE cryptominisat5 "${_py_implib}")
+        else()
+            target_link_libraries(pycryptosat PRIVATE cryptominisat5 "${_py_base}/python3.dll")
+        endif()
         set_target_properties(pycryptosat PROPERTIES PREFIX "" SUFFIX ".pyd")
     else()
         find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -665,24 +665,9 @@ if(BUILD_PYTHON_EXTENSION)
             "${_py_base}/include"
             ${PROJECT_SOURCE_DIR}/src
             ${PROJECT_SOURCE_DIR})
-        # Create a proper import library for the Python DLL to avoid
-        # --enable-auto-import which can pull symbols from unrelated
-        # DLLs on PATH at runtime (causing debug/release mixing crashes).
-        get_filename_component(_py_dll_name "${_py_dll}" NAME_WE)
-        set(_py_def "${CMAKE_CURRENT_BINARY_DIR}/${_py_dll_name}.def")
-        set(_py_implib "${CMAKE_CURRENT_BINARY_DIR}/lib${_py_dll_name}.dll.a")
-        add_custom_command(OUTPUT "${_py_def}"
-            COMMAND gendef "${_py_dll}"
-            WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-            DEPENDS "${_py_dll}"
-            COMMENT "Generating .def from ${_py_dll}")
-        add_custom_command(OUTPUT "${_py_implib}"
-            COMMAND dlltool -d "${_py_def}" -l "${_py_implib}" -D "${_py_dll}"
-            DEPENDS "${_py_def}"
-            COMMENT "Creating import library for ${_py_dll}")
-        add_custom_target(_py_implib_target DEPENDS "${_py_implib}")
-        add_dependencies(pycryptosat _py_implib_target)
-        target_link_libraries(pycryptosat PRIVATE cryptominisat5 "${_py_implib}")
+        target_link_libraries(pycryptosat PRIVATE cryptominisat5 "${_py_dll}")
+        target_link_options(pycryptosat PRIVATE
+            "SHELL:-Wl,--enable-auto-import")
         set_target_properties(pycryptosat PROPERTIES PREFIX "" SUFFIX ".pyd")
     else()
         find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,11 @@ repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
 # GMP is not a macOS system library; brew installs it and delocate bundles it.
 before-all = "brew install gmp ccache || true"
 repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
+
+[tool.cibuildwheel.windows]
+# MinGW/MSYS2 toolchain (GCC, GMP, zlib, pkg-config) is installed by the
+# workflow step before cibuildwheel runs.  CMake uses the Ninja generator
+# with the MinGW compilers (set via CIBW_ENVIRONMENT_WINDOWS in the workflow).
+# delvewheel automatically bundles MinGW runtime DLLs (libstdc++, libgmp, etc.).
+test-command = "cd %TEMP% && pytest {project}/python/tests"
+repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -349,17 +349,30 @@ set(HEADER_DEST "${PROJECT_BINARY_DIR}/include/cryptominisat5")
 add_custom_target(CopyPublicHeaders_cryptominisat5 ALL)
 foreach(public_header ${cryptominisat5_public_headers})
     get_filename_component(HEADER_NAME ${public_header} NAME)
-    add_custom_command(TARGET CopyPublicHeaders_cryptominisat5 PRE_BUILD
-                       COMMAND ${CMAKE_COMMAND} -E make_directory
-                               "${HEADER_DEST}"
-                       COMMAND ${CMAKE_COMMAND} -E echo
-                       "Symlinking ${HEADER_NAME} to ${HEADER_DEST}"
-                       COMMAND ${CMAKE_COMMAND} -E remove
-                               "${HEADER_DEST}/${HEADER_NAME}"
-                       COMMAND ${CMAKE_COMMAND} -E create_symlink
-                               "${public_header}"
-                               "${HEADER_DEST}/${HEADER_NAME}"
-                      )
+    if(WIN32)
+        # Windows: use copy instead of symlink (symlinks require Developer Mode)
+        add_custom_command(TARGET CopyPublicHeaders_cryptominisat5 PRE_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E make_directory
+                                   "${HEADER_DEST}"
+                           COMMAND ${CMAKE_COMMAND} -E echo
+                           "Copying ${HEADER_NAME} to ${HEADER_DEST}"
+                           COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                                   "${public_header}"
+                                   "${HEADER_DEST}/${HEADER_NAME}"
+                          )
+    else()
+        add_custom_command(TARGET CopyPublicHeaders_cryptominisat5 PRE_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E make_directory
+                                   "${HEADER_DEST}"
+                           COMMAND ${CMAKE_COMMAND} -E echo
+                           "Symlinking ${HEADER_NAME} to ${HEADER_DEST}"
+                           COMMAND ${CMAKE_COMMAND} -E remove
+                                   "${HEADER_DEST}/${HEADER_NAME}"
+                           COMMAND ${CMAKE_COMMAND} -E create_symlink
+                                   "${public_header}"
+                                   "${HEADER_DEST}/${HEADER_NAME}"
+                          )
+    endif()
 endforeach()
 
 generate_export_header(cryptominisat5)
@@ -414,17 +427,30 @@ set(ORACLE_HEADER_DEST "${PROJECT_BINARY_DIR}/include/oracle")
 add_custom_target(CopyPublicHeaders_oracle ALL)
 foreach(public_header ${oracle_public_headers})
     get_filename_component(HEADER_NAME ${public_header} NAME)
-    add_custom_command(TARGET CopyPublicHeaders_oracle PRE_BUILD
-                       COMMAND ${CMAKE_COMMAND} -E make_directory
-                               "${ORACLE_HEADER_DEST}"
-                       COMMAND ${CMAKE_COMMAND} -E echo
-                       "Symlinking ${HEADER_NAME} to ${ORACLE_HEADER_DEST}"
-                       COMMAND ${CMAKE_COMMAND} -E remove
-                               "${ORACLE_HEADER_DEST}/${HEADER_NAME}"
-                       COMMAND ${CMAKE_COMMAND} -E create_symlink
-                               "${public_header}"
-                               "${ORACLE_HEADER_DEST}/${HEADER_NAME}"
-                      )
+    if(WIN32)
+        # Windows: use copy instead of symlink (symlinks require Developer Mode)
+        add_custom_command(TARGET CopyPublicHeaders_oracle PRE_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E make_directory
+                                   "${ORACLE_HEADER_DEST}"
+                           COMMAND ${CMAKE_COMMAND} -E echo
+                           "Copying ${HEADER_NAME} to ${ORACLE_HEADER_DEST}"
+                           COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                                   "${public_header}"
+                                   "${ORACLE_HEADER_DEST}/${HEADER_NAME}"
+                          )
+    else()
+        add_custom_command(TARGET CopyPublicHeaders_oracle PRE_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E make_directory
+                                   "${ORACLE_HEADER_DEST}"
+                           COMMAND ${CMAKE_COMMAND} -E echo
+                           "Symlinking ${HEADER_NAME} to ${ORACLE_HEADER_DEST}"
+                           COMMAND ${CMAKE_COMMAND} -E remove
+                                   "${ORACLE_HEADER_DEST}/${HEADER_NAME}"
+                           COMMAND ${CMAKE_COMMAND} -E create_symlink
+                                   "${public_header}"
+                                   "${ORACLE_HEADER_DEST}/${HEADER_NAME}"
+                          )
+    endif()
 endforeach()
 
 add_executable(oracle-bin

--- a/src/occsimplifier.cpp
+++ b/src/occsimplifier.cpp
@@ -3350,8 +3350,15 @@ bool OccSimplifier::find_irreg_gate(
     out_a.clear();
     out_b.clear();
 
-    assert(picosat == nullptr);
+    // Use Windows HeapAlloc to avoid MSVCRT malloc contention under threads
+    #ifdef _WIN32
+    auto picosat_m = [](void*,size_t s) -> void* { return HeapAlloc(GetProcessHeap(), 0, s); };
+    auto picosat_r = [](void*,void* p,size_t,size_t s) -> void* { return p ? HeapReAlloc(GetProcessHeap(), 0, p, s) : HeapAlloc(GetProcessHeap(), 0, s); };
+    auto picosat_f = [](void*,void* p,size_t) { if(p) HeapFree(GetProcessHeap(), 0, p); };
+    picosat = picosat_minit(nullptr, picosat_m, picosat_r, picosat_f);
+    #else
     picosat = picosat_init();
+    #endif
     int ret = picosat_enable_trace_generation(picosat);
     assert(ret != 0 && "Traces cannot be generated in PicoSAT, wrongly configured&built");
 


### PR DESCRIPTION
- Add windows-latest to the build matrix in python-wheels.yml
- Set up MSYS2 with MinGW toolchain (gcc, cmake, ninja, gmp, zlib, pkg-config, ccache)
- Add MinGW to PATH and set CC/CXX for cibuildwheel
- Configure CMAKE_GENERATOR=Ninja and PKG_CONFIG_PATH via CIBW_ENVIRONMENT_WINDOWS
- Add [tool.cibuildwheel.windows] to pyproject.toml with delvewheel repair and Windows-compatible test-command

Windows was already present in build.yml and release.yml but was never added to the Python wheel workflow. This uses the same MSYS2/MinGW approach.